### PR TITLE
Allow to reproduce builds locally using minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,19 +93,19 @@ eval $(minikube -p minikube docker-env)
 Most likely you'll need to build the base image only once (it doesn't get modified too often but building it takes quite a lot of time), e.g.:
 
 ```shell
-scripts/build-builder-base.sh v0.0.3
+scripts/build-builder-base.sh v0.0.4
 ```
 
 Build all the remaining images
 
 ```shell
-scripts/build-quick.sh v0.0.3
+scripts/build-quick.sh v0.0.4
 ```
 
 or (re)build each image separately e.g.
 
 ```shell
-scripts/build-mvn-repo.sh v0.0.3
+scripts/build-mvn-repo.sh v0.0.4
 ```
 
 ### Deploying and debugging in k8s

--- a/coordinator/src/main/scala/buildPlan.scala
+++ b/coordinator/src/main/scala/buildPlan.scala
@@ -147,7 +147,7 @@ def makeStepsBasedBuildPlan(depGraph: DependencyGraph): BuildPlan =
   BuildPlan(depGraph.scalaRelease, computedSteps._1)
 
 @main def printBuildPlan: BuildPlan = 
-  val deps = loadDepenenecyGraph("3.x", minStarsCount = 100)
+  val deps = loadDepenenecyGraph("3", minStarsCount = 100)
   val plan = makeStepsBasedBuildPlan(deps)
   val niceSteps = plan.steps.zipWithIndex.map { case (steps, nr) =>
     val items = 
@@ -284,7 +284,7 @@ private given FromString[Seq[Project]] = str =>
   }
 
 @main def storeDependenciesBasedBuildPlan(
-    scalaBinaryVersionSeries: String,
+    scalaBinaryVersion: String,
     minStarsCount: Int,
     maxProjectsCount: Int,
     requiredProjects: Seq[Project],
@@ -292,16 +292,12 @@ private given FromString[Seq[Project]] = str =>
     projectsConfigPath: String,
     projectsFilterPath: String
 ) =
-  val filterPatterns = io.Source
-    .fromFile(projectsFilterPath)
-    .getLines
-    .map(_.trim())
-    .filterNot(_.startsWith("#"))
-    .filter(_.nonEmpty)
+  val fi  println(s"using Scala binary version: $scalaBinaryVersion")
+ter(_.nonEmpty)
     .toSeq
     
   val depGraph = loadDepenenecyGraph(
-    scalaBinaryVersionSeries,
+    scalaBinaryVersion,
     minStarsCount = minStarsCount,
     maxProjectsCount = Option(maxProjectsCount).filter(_ >= 0),
     requiredProjects = requiredProjects,

--- a/coordinator/src/main/scala/buildPlan.scala
+++ b/coordinator/src/main/scala/buildPlan.scala
@@ -292,8 +292,12 @@ private given FromString[Seq[Project]] = str =>
     projectsConfigPath: String,
     projectsFilterPath: String
 ) =
-  val fi  println(s"using Scala binary version: $scalaBinaryVersion")
-ter(_.nonEmpty)
+  val filterPatterns = io.Source
+    .fromFile(projectsFilterPath)
+    .getLines
+    .map(_.trim())
+    .filterNot(_.startsWith("#"))
+    .filter(_.nonEmpty)
     .toSeq
     
   val depGraph = loadDepenenecyGraph(

--- a/coordinator/src/main/scala/core.scala
+++ b/coordinator/src/main/scala/core.scala
@@ -49,7 +49,7 @@ case class ProjectBuildDef(name: String, dependencies: Array[String], repoUrl: S
 // Community projects configs
 case class JavaConfig(version: Option[String] = None) derives ConfigReader
 case class SbtConfig(commands: List[String] = Nil, options: List[String] = Nil) derives ConfigReader
-case class MillConfig(exclude: List[String] = Nil, options: List[String] = Nil) derives ConfigReader
+case class MillConfig(options: List[String] = Nil) derives ConfigReader
 case class ProjectsConfig(exclude: List[String] = Nil)
 case class ProjectBuildConfig(
     projects: ProjectsConfig = ProjectsConfig(),

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -30,6 +30,12 @@ typelevel_fs2 {
   java.version=17
 }
 
+typelevel_jawn {
+  projects.exclude=[
+    "com.eed3si9n%shaded-jawn-parser"
+  ]
+}
+
 wvlet_airframe {
   projects.exclude=[
     "org.wvlet.airframe%airspec" # Inner sbt project, no mechanism to handle that currently

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -36,6 +36,18 @@ typelevel_jawn {
   ]
 }
 
+thoughtworksinc_binding.scala {
+  // Not a part of the repositroy
+  projects.exclude=[
+    "com.thoughtworks.binding%bindable-bindableseq"
+    "com.thoughtworks.binding%covariantstreamt",
+    "com.thoughtworks.binding%defaultfuture"
+    "com.thoughtworks.binding%keywords-bind"
+    "com.thoughtworks.binding%patchstreamt"
+    "com.thoughtworks.binding%streamt"
+  ]
+}
+
 wvlet_airframe {
   projects.exclude=[
     "org.wvlet.airframe%airspec" # Inner sbt project, no mechanism to handle that currently

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -1,5 +1,3 @@
-monix/minitest dotty-staging/minitest
-milessabin/shapeless dotty-staging/shapeless shapeless-3-staging
 playframework/play-json dotty-staging/play-json
 playframework/playframework dotty-staging/play-json
 spray/spray spray/spray-json v1.3.6-3.1.0

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -1,3 +1,4 @@
+milessabin/shapeless typelevel/shapeless-3
 playframework/play-json dotty-staging/play-json
 playframework/playframework dotty-staging/play-json
 spray/spray spray/spray-json v1.3.6-3.1.0

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -82,7 +82,7 @@ pipeline {
                               requests:
                                 memory: 5Gi
                               limits:
-                                memory: 6Gi
+                                memory: 7Gi
                             env:
                             - name: ELASTIC_USERNAME
                               value: ${params.elasticSearchUserName}

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -167,6 +167,12 @@ pipeline {
                       }
                     }
                 }
+                failure {
+                  script {
+                    echo "Build failed, reproduce it locally using following command:"
+                    echo "scala-cli run https://raw.githubusercontent.com/VirtusLab/community-build3/master/reproducer/reproducer.scala -- --jobId=${env.BUILD_NUMBER}"
+                  }
+                }
             }
         }
     }

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -64,7 +64,7 @@ pipeline {
                               name: mvn-repo-cert
                           containers:
                           - name: project-builder
-                            image: virtuslab/scala-community-build-project-builder:jdk${params.javaVersion?: 11}-v0.0.3
+                            image: virtuslab/scala-community-build-project-builder:jdk${params.javaVersion?: 11}-v0.0.4
                             imagePullPolicy: IfNotPresent
                             volumeMounts:
                             - name: mvn-repo-cert

--- a/jenkins/seeds/buildCompiler.groovy
+++ b/jenkins/seeds/buildCompiler.groovy
@@ -33,7 +33,7 @@ pipeline {
                               name: mvn-repo-cert
                           containers:
                           - name: compiler-builder
-                            image: virtuslab/scala-community-build-compiler-builder:v0.0.3
+                            image: virtuslab/scala-community-build-compiler-builder:v0.0.4
                             imagePullPolicy: IfNotPresent
                             volumeMounts:
                             - name: mvn-repo-cert

--- a/jenkins/seeds/computeBuildPlan.groovy
+++ b/jenkins/seeds/computeBuildPlan.groovy
@@ -24,7 +24,7 @@ pipeline {
                         spec:
                           containers:
                           - name: coordinator
-                            image: virtuslab/scala-community-build-coordinator:v0.0.3
+                            image: virtuslab/scala-community-build-coordinator:v0.0.4
                             imagePullPolicy: IfNotPresent
                             command:
                             - cat
@@ -42,7 +42,7 @@ pipeline {
                               cat << EOF > /tmp/maintained-project-configs.conf \n${params.projectsConfig}\nEOF
                               cat << EOF > /tmp/projects-filters.txt \n${params.projectsFilters}\nEOF
                               /build/compute-build-plan.sh \
-                               '${params.scalaBinaryVersionSeries}' \
+                               '${params.scalaBinaryVersion}' \
                                '${params.minStarsCount}' \
                                '${params.maxProjectsCount}' \
                                '${params.requiredProjects}' \

--- a/jenkins/seeds/initializeSeedJobs.groovy
+++ b/jenkins/seeds/initializeSeedJobs.groovy
@@ -42,7 +42,7 @@ pipelineJob('/runBuild') {
             sectionHeaderStyle("")
         }
         stringParam("precomputedBuildPlan", null, "(Optional, for debugging purposes mainly): The build plan (in JSON format) to be used instead of computing the plan dynamically. When specified, the remaining parameters from this section are ignored")
-        stringParam("scalaBinaryVersionSeries", "3.x", "Scala binary version following Scaladex API convention used for detecting projects to be built")
+        stringParam("scalaBinaryVersion", "3", "Scala binary version following Scaladex API convention used for detecting projects to be built")
         stringParam("minStarsCount", "100", "Minimal number of start on GitHub required to include a project into the build plan")
         stringParam("maxProjectsCount", "40", "Maximal number of projects to include into the build plan")
         stringParam("requiredProjects", requiredProjectsConfig, "Comma-sepatrated list of projects that have to be included into the build plan (using GitHub coordinates), e.g. 'typelevel/cats,scalaz/scalaz'")
@@ -95,7 +95,7 @@ pipelineJob('/computeBuildPlan') {
     }
     parameters {
         stringParam("buildName")
-        stringParam("scalaBinaryVersionSeries", "3.x", "Scala binary version following Scaladex API convention used for detecting projects to be built")
+        stringParam("scalaBinaryVersion", "3", "Scala binary version following Scaladex API convention used for detecting projects to be built")
         stringParam("minStarsCount", "100", "Minimal number of start on GitHub required to include a project into the build plan")
         stringParam("maxProjectsCount", "40", "Maximal number of projects to include into the build plan")
         stringParam("requiredProjects", requiredProjectsConfig, "Comma-sepatrated list of projects that have to be included into the build plan (using GitHub coordinates), e.g. 'typelevel/cats,scalaz/scalaz'")

--- a/jenkins/seeds/runBuild.groovy
+++ b/jenkins/seeds/runBuild.groovy
@@ -60,7 +60,7 @@ pipeline {
                             buildPlanJobRef = build(
                                 job: buildPlanJobName,
                                 parameters: [
-                                    string(name: "scalaBinaryVersionSeries", value: params.scalaBinaryVersionSeries),
+                                    string(name: "scalaBinaryVersion", value: params.scalaBinaryVersion),
                                     string(name: "minStarsCount", value: params.minStarsCount),
                                     string(name: "maxProjectsCount", value: params.maxProjectsCount),
                                     string(name: "requiredProjects", value: params.requiredProjects),

--- a/k8s/mvn-repo.yaml
+++ b/k8s/mvn-repo.yaml
@@ -20,7 +20,7 @@ spec:
           secretName: mvn-repo-keystore
       containers:
       - name: mvn-repo
-        image: virtuslab/scala-community-build-mvn-repo:v0.0.3
+        image: virtuslab/scala-community-build-mvn-repo:v0.0.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/project-builder/Dockerfile
+++ b/project-builder/Dockerfile
@@ -9,4 +9,7 @@ RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux
   && sh -c "mill --version" \ 
   && sh -c "scalafix --version"
 
+# Project dependencies
+RUN apt -y install git-lfs 
+
 COPY . /build/

--- a/project-builder/checkout.sh
+++ b/project-builder/checkout.sh
@@ -15,8 +15,8 @@ echo Clonning $repo into $repoDir using revision $rev
 echo '##################################'
 
 rm -rf "$repoDir"
+branch=""
 if [ -n "$rev" ]; then
-  git clone "$repo" "$repoDir" -b "$rev" --depth 1
-else
-  git clone "$repo" "$repoDir" --depth 1
+  branch="-b $rev"
 fi
+git clone "$repo" "$repoDir" $branch

--- a/project-builder/checkout.sh
+++ b/project-builder/checkout.sh
@@ -19,4 +19,4 @@ branch=""
 if [ -n "$rev" ]; then
   branch="-b $rev"
 fi
-git clone "$repo" "$repoDir" $branch
+git clone --quiet "$repo" "$repoDir" $branch

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -172,9 +172,7 @@ def runBuild(targets: Seq[String])(implicit ctx: Ctx) = {
       }
     )
     ModuleBuildResults(
-      organization = org,
       artifactName = name,
-      projectName = module.toString,
       results = results
     )
   }
@@ -320,15 +318,12 @@ case class ModuleTargetsResults(
   }
 }
 case class ModuleBuildResults(
-    projectName: String, // Name of the project in the build tool
-    organization: String,
-    artifactName: String, // Name of the produced artifact
+    artifactName: String,
     results: ModuleTargetsResults
 ) {
   lazy val toJson = {
     val resultsJson = results.jsonValues.mkString(", ")
-    val metadata = s""""meta": {"organization": "$organization", "projectName": "$projectName"}"""
-    s""""$artifactName": {$resultsJson, $metadata}"""
+    s""""$artifactName": {$resultsJson}"""
   }
 }
 

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -8,22 +8,20 @@ import coursier.maven.MavenRepository
 import coursier.Repository
 
 trait CommunityBuildCoursierModule extends CoursierModule { self: JavaModule =>
-  protected val mavenRepoUrl: String = sys.props
+  protected val mavenRepoUrl: Option[String] = sys.props
     .get("communitybuild.maven.url")
     .map(_.stripSuffix("/"))
-    .getOrElse {
-      sys.error("Required property 'communitybuild.maven.url' not set")
-    }
+  private val mavenRepo = mavenRepoUrl.map(MavenRepository(_))
 
   override def repositoriesTask: Task[Seq[Repository]] = T.task {
-    MavenRepository(mavenRepoUrl) +: super.repositoriesTask()
+    mavenRepo.foldLeft(super.repositoriesTask())(_ :+ _)
   }
   // Override zinc worker, we need to set custom repostitories there are well,
   // to allow to use our custom repo
   override def zincWorker = CommunityBuildZincWorker
   object CommunityBuildZincWorker extends ZincWorkerModule with CoursierModule {
     override def repositoriesTask() = T.task {
-      MavenRepository(mavenRepoUrl) +: super.repositoriesTask()
+      mavenRepo.foldLeft(super.repositoriesTask())(_ :+ _)
     }
   }
 }
@@ -38,7 +36,8 @@ trait CommunityBuildPublishModule extends PublishModule with CommunityBuildCours
     }
     for {
       (artifactPath, artifactName) <- artifacts
-      url = s"$mavenRepoUrl/$artifactModulePath/$artifactName"
+      repoUrl <- mavenRepoUrl
+      url = s"$repoUrl/$artifactModulePath/$artifactName"
     } {
       val res = put(
         url = url,
@@ -47,7 +46,7 @@ trait CommunityBuildPublishModule extends PublishModule with CommunityBuildCours
       )
       if (!res.is2xx) {
         throw new RuntimeException(
-          s"Failed to publish artifact ${url.stripPrefix(mavenRepoUrl)}: ${res.statusMessage}"
+          s"Failed to publish artifact ${url.stripPrefix(repoUrl)}: ${res.statusMessage}"
         )
       }
     }
@@ -88,7 +87,9 @@ def mapCrossVersions(
   }
 }
 
-private case class ModuleInfo(name: String, module: Module)
+case class ModuleInfo(org: String, name: String, module: Module) {
+  val targetName = s"$org%$name"
+}
 case class Ctx(
     root: mill.define.Module,
     scalaVersion: String,
@@ -102,24 +103,35 @@ case class Ctx(
 // Main entry point for Mill community build
 // Evaluate tasks until first failure and publish report
 def runBuild(targets: Seq[String])(implicit ctx: Ctx) = {
-  def runTasks(module: Module): List[BuildStepResult] = {
-    mapEval[List[BuildStepResult]](module, "compile")(CompileFailed :: Nil) {
-      val testResult = mapEval[BuildStepResult](module, "test", "compile")(TestFailed)(TestOk)
-      val publishResult = ctx.publishVersion.fold[BuildStepResult](PublishSkipped) {
-        publishVersion =>
-          evalOrThrow(module, "publishVersion") match {
-            case Result.Success(`publishVersion`) =>
-              mapEval[BuildStepResult](module, "publishCommunityBuild")(PublishFailed)(PublishOk)
-            case Result.Success(version: String) =>
-              PublishWrongVersion(Some(version))
-            case _ => PublishFailed
-          }
+  class TaskEvaluator(module: Module) {
+    def eval(labels: String*) = {
+      lazy val renderedPath = s"$module.${Segments(labels.map(Label(_)): _*).render}"
+
+      tryEval(module, labels: _*)
+        .fold[BuildStepResult] {
+          // Target not found, skip it and treat as successfull
+          ctx.log.error(s"Not found target '$renderedPath', skipping.")
+          BuildError(s"Not found target '$renderedPath'")
+        } {
+          case Result.Success(v) =>
+            ctx.log.info(s"Successfully evaluated $renderedPath")
+            Ok
+          case failure =>
+            ctx.log.error(s"Failed to evaluated $renderedPath: ${failure}")
+            Failed
+        }
+    }
+    def evalAsDependencyOf(
+        dependecyOf: => BuildStepResult
+    )(labels: String*): BuildStepResult = {
+      dependecyOf match {
+        case _: FailedBuildStep => Skipped
+        case _                  => eval(labels: _*)
       }
-      CompileOk :: testResult :: publishResult :: Nil
     }
   }
 
-  val mappings = moduleMappings(targets.toSet)
+  val mappings = checkedModuleMappings(targets.toSet)
   val topLevelModules = mappings.collect {
     case (target, info) if targets.contains(target) => info
   }.toSet
@@ -139,28 +151,37 @@ def runBuild(targets: Seq[String])(implicit ctx: Ctx) = {
     }
 
   val projectsBuildResults = for {
-    ModuleInfo(name, module) <- flatten(topLevelModules, topLevelModules)
-  } yield Info(name) :: {
+    ModuleInfo(org, name, module) <- flatten(topLevelModules, topLevelModules)
+  } yield {
     ctx.log.info(s"Starting build for $name")
-    try runTasks(module)
-    catch {
-      case ex: Throwable =>
-        ctx.log.error("Failed to evaluate tasks")
-        ex.printStackTrace()
-        BuildError(ex.getMessage) :: Nil
-    }
+    val evaluator = new TaskEvaluator(module)
+    import evaluator._
+
+    val compileResult = eval("compile")
+    val results = ModuleTargetsResults(
+      compile = compileResult,
+      testsCompile = evalAsDependencyOf(compileResult)("test", "compile"),
+      publish = ctx.publishVersion.fold[BuildStepResult](Skipped) { publishVersion =>
+        tryEval(module, "publishVersion")
+          .fold[BuildStepResult](BuildError("No task 'publishVersion'")) {
+            case Result.Success(`publishVersion`) => eval("publishCommunityBuild")
+            case Result.Success(version: String) =>
+              WrongVersion(expected = publishVersion, got = version)
+            case _ => BuildError("Failed to resolve 'publishVersion'")
+          }
+      }
+    )
+    ModuleBuildResults(
+      organization = org,
+      artifactName = name,
+      moduleName = module.toString,
+      results = results
+    )
   }
 
   val buildSummary = projectsBuildResults
-    .map {
-      case List(result) => result.asString
-      case subProjectName :: subProjectResults =>
-        val subProject = subProjectName.asString
-        val results = subProjectResults.map(_.asString).mkString("{", ", ", "}")
-        s"$subProject: $results"
-    }
+    .map(_.toJson)
     .mkString("{", ", ", "}")
-
   ctx.log.info(s"""
     |************************
     |Build summary:
@@ -171,9 +192,10 @@ def runBuild(targets: Seq[String])(implicit ctx: Ctx) = {
   val outputDir = os.pwd / os.up
   os.write.over(outputDir / "build-summary.txt", buildSummary)
 
-  val hasFailedSteps =
-    projectsBuildResults.exists(_.exists(_.isInstanceOf[BuildStepFailure]))
-  val buildStatus = if (!hasFailedSteps) "success" else "failure"
+  val hasFailedSteps = projectsBuildResults.exists(_.results.hasFailedStep)
+  val buildStatus =
+    if (hasFailedSteps) "failure"
+    else "success"
   os.write.over(outputDir / "build-status.txt", buildStatus)
   if (hasFailedSteps) {
     throw new ProjectBuildFailureException
@@ -184,14 +206,13 @@ private def toMappingInfo(module: Module)(implicit ctx: Ctx): Option[(String, Mo
   for {
     Result.Success(publish.Artifact(org, _, _)) <- tryEval(module, "artifactMetadata")
     Result.Success(name: String) <- tryEval(module, "artifactName")
-    targetName = s"$org%$name"
-  } yield targetName -> ModuleInfo(name, module)
+    info = ModuleInfo(org, name, module)
+  } yield info.targetName -> info
 }
 
-private def moduleMappings(
-    targetStrings: Set[String]
-)(implicit ctx: Ctx): Map[String, ModuleInfo] = {
-  val mappings = ctx.root.millInternal.modules.flatMap { module =>
+type ModuleMappings = Map[String, ModuleInfo]
+def moduleMappings(implicit ctx: Ctx): ModuleMappings = {
+  ctx.root.millInternal.modules.flatMap { module =>
     for {
       Result.Success(scalaVersion) <- tryEval(module, "scalaVersion")
       if scalaVersion == ctx.scalaVersion
@@ -199,13 +220,15 @@ private def moduleMappings(
       Result.Success(platformSuffix: String) <- tryEval(module, "platformSuffix")
       if platformSuffix.isEmpty // is JVM
 
-      Result.Success(publish.Artifact(org, _, _)) <- tryEval(module, "artifactMetadata")
-      Result.Success(name: String) <- tryEval(module, "artifactName")
-      mapping @ (targetName, ModuleInfo(_, module)) <- toMappingInfo(module)
-      _ = ctx.log.info(s"Using $module for $targetName")
+      mapping @ (targetName, ModuleInfo(_, _, module)) <- toMappingInfo(module)
     } yield mapping
   }.toMap
+}
 
+private def checkedModuleMappings(
+    targetStrings: Set[String]
+)(implicit ctx: Ctx): ModuleMappings = {
+  val mappings = moduleMappings(ctx)
   val unmatched = targetStrings.diff(mappings.keySet)
   if (unmatched.nonEmpty) {
     sys.error(
@@ -242,40 +265,6 @@ private def tryEval(module: Module, labels: String*)(implicit ctx: Ctx) = {
     }
 }
 
-private def mapEval[T](module: Module, labels: String*)(
-    onFailure: => T
-)(onSucces: => T)(implicit ctx: Ctx) = {
-  lazy val renderedPath =
-    s"$module.${Segments(labels.map(Label(_)): _*).render}"
-
-  tryEval(module, labels: _*)
-    .fold {
-      // Target not found, skip it and treat as successfull
-      ctx.log.error(s"Not found target '$renderedPath', skipping.")
-      onSucces
-    } {
-      case Result.Success(v) =>
-        ctx.log.info(s"Successfully evaluated $renderedPath")
-        onSucces
-      case failure =>
-        ctx.log.error(s"Failed to evaluated $renderedPath: ${failure}")
-        onFailure
-    }
-}
-
-private def evalOrThrow(module: Module, segments: String*)(implicit
-    ctx: Ctx
-) = {
-  val segmentsAsLabels = segments.map(Label(_))
-  tryEval(module, segments: _*)
-    .getOrElse {
-      val outerCtx = module.millOuterCtx
-      val segments = outerCtx.segments ++ (outerCtx.segment +: segmentsAsLabels)
-      val path = segments.render
-      sys.error(s"Failed to eval $path")
-    }
-}
-
 // Extractors
 private case class ExtractorsCtx(scalaVersion: String) {
   val SymVer(scalaMajor, scalaMinor, _, _) = scalaVersion
@@ -297,21 +286,50 @@ private object MatchesScalaBinaryVersion {
   }
 }
 
-// Step results
-abstract class BuildStepResult(val asString: String)
-abstract class BuildStepFailure(stringValue: String) extends BuildStepResult(stringValue)
-abstract class BuildStepSuccess(stringValue: String) extends BuildStepResult(stringValue)
+sealed abstract class BuildStepResult(val stringValue: String) {
+  def jsonValue = s""""$stringValue""""
+}
+sealed abstract class FailedBuildStep(name: String, info: List[(String, String)])
+    extends BuildStepResult(name) {
+  override def jsonValue =
+    if (info.isEmpty) s""""$name""""
+    else {
+      val infoFields = info.map { case (k, v) => s""""$k": "$v"""" }.mkString(", ")
+      s""""$name": {$infoFields}"""
+    }
+}
+case object Ok extends BuildStepResult("ok")
+case object Skipped extends BuildStepResult("skipped")
+case object Failed extends FailedBuildStep("failed", Nil)
+case class WrongVersion(expected: String, got: String)
+    extends FailedBuildStep("wrongVersion", List("expected" -> expected, "got" -> got))
+case class BuildError(msg: String) extends FailedBuildStep("buildError", List("reason" -> msg))
 
-case class Info(msg: String) extends BuildStepSuccess(s""""$msg"""")
-object CompileOk extends BuildStepSuccess(""""compile": "ok"""")
-object CompileFailed extends BuildStepFailure(""""compile": "failed"""")
-object TestOk extends BuildStepSuccess(""""test": "ok"""")
-object TestFailed extends BuildStepFailure(""""test": "failed"""")
-object PublishSkipped extends BuildStepSuccess(""""publish": "skipped"""")
-case class PublishWrongVersion(version: Option[String])
-    extends BuildStepFailure(s""""publish": "wrongVersion=${version}"""")
-object PublishOk extends BuildStepSuccess(""""publish": "ok"""")
-object PublishFailed extends BuildStepFailure(""""publish": "failed"""")
-case class BuildError(msg: String) extends BuildStepFailure(s""""error": "${msg}"""")
+case class ModuleTargetsResults(
+    compile: BuildStepResult,
+    testsCompile: BuildStepResult,
+    publish: BuildStepResult
+) {
+  def hasFailedStep: Boolean = this.productIterator.exists(_.isInstanceOf[FailedBuildStep])
+  def jsonValues: List[String] = List(
+    "compile" -> compile,
+    "test-compile" -> testsCompile,
+    "publish" -> publish
+  ).map { case (key, value) =>
+    s""""$key": "${value.stringValue}""""
+  }
+}
+case class ModuleBuildResults(
+    moduleName: String,
+    organization: String,
+    artifactName: String,
+    results: ModuleTargetsResults
+) {
+  lazy val toJson = {
+    val resultsJson = results.jsonValues.mkString(", ")
+    val metadata = s""""meta": {"organization": "$organization", "moduleName": "$moduleName"}"""
+    s""""$artifactName": {$resultsJson, $metadata}"""
+  }
+}
 
 class ProjectBuildFailureException extends Exception

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -174,7 +174,7 @@ def runBuild(targets: Seq[String])(implicit ctx: Ctx) = {
     ModuleBuildResults(
       organization = org,
       artifactName = name,
-      moduleName = module.toString,
+      projectName = module.toString,
       results = results
     )
   }
@@ -320,14 +320,14 @@ case class ModuleTargetsResults(
   }
 }
 case class ModuleBuildResults(
-    moduleName: String,
+    projectName: String, // Name of the project in the build tool
     organization: String,
-    artifactName: String,
+    artifactName: String, // Name of the produced artifact
     results: ModuleTargetsResults
 ) {
   lazy val toJson = {
     val resultsJson = results.jsonValues.mkString(", ")
-    val metadata = s""""meta": {"organization": "$organization", "moduleName": "$moduleName"}"""
+    val metadata = s""""meta": {"organization": "$organization", "projectName": "$projectName"}"""
     s""""$artifactName": {$resultsJson, $metadata}"""
   }
 }

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -111,7 +111,7 @@ def runBuild(targets: Seq[String])(implicit ctx: Ctx) = {
         .fold[BuildStepResult] {
           // Target not found, skip it and treat as successfull
           ctx.log.error(s"Not found target '$renderedPath', skipping.")
-          BuildError(s"Not found target '$renderedPath'")
+          Skipped
         } {
           case Result.Success(v) =>
             ctx.log.info(s"Successfully evaluated $renderedPath")

--- a/project-builder/mill/prepare-project.sh
+++ b/project-builder/mill/prepare-project.sh
@@ -21,6 +21,7 @@ cp repo/build.sc repo/build.scala \
     --files repo/build.scala \
     --stdout \
     --syntactic \
+    --settings.Scala3CommunityBuildMillAdapter.targetScalaVersion "$scalaVersion" \
     --scala-version 3.1.0 > repo/build.sc \
   && rm repo/build.scala 
 

--- a/project-builder/mill/scalafix/input/src/main/scala/fix/MillCrossOverride.scala
+++ b/project-builder/mill/scalafix/input/src/main/scala/fix/MillCrossOverride.scala
@@ -10,10 +10,13 @@ object MillCrossOverride {
   }
 
   sealed abstract class MillCommunityBuildCross[T](cases: Any*)(version: String)
+  val versions = List()
 
   import mill._
 
   object module extends Cross[ModuleType]((Seq("2.13.8", "3.0.0") ++ Option("3.1.0")): _*)
   object module2 extends _root_.fix.MillCrossOverride.mill.Cross[ModuleType]((Seq("2.13.8", "3.0.0") ++ Option("3.1.0")): _*)
   val module3 = new mill.Cross[mill.ModuleType]("2.13.8", "3.1.0"){}
+  object module4 extends Cross[ModuleType](versions:_*)
+
 }

--- a/project-builder/mill/scalafix/input/src/main/scala/fix/MillPublishVersionOverride.scala
+++ b/project-builder/mill/scalafix/input/src/main/scala/fix/MillPublishVersionOverride.scala
@@ -5,6 +5,7 @@ package fix
 
 object MillPublishVersionOverride {
   final val Version = "3.1.1"
+  def T[U](v: U): U = ???
 
   object module {
     val publishVersion = "3.0.0"

--- a/project-builder/mill/scalafix/output/src/main/scala/fix/MillCrossOverride.scala
+++ b/project-builder/mill/scalafix/output/src/main/scala/fix/MillCrossOverride.scala
@@ -7,10 +7,13 @@ object MillCrossOverride {
   }
 
   sealed abstract class MillCommunityBuildCross[T](cases: Any*)(version: String)
+  val versions = List()
 
   import mill._
 
-  object module extends MillCommunityBuildCross[ModuleType]((Seq("2.13.8", "3.0.0") ++ Option("3.1.0")): _*)(_root_.scala.sys.props.get("communitybuild.scala").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.scala'")))
-  object module2 extends MillCommunityBuildCross[ModuleType]((Seq("2.13.8", "3.0.0") ++ Option("3.1.0")): _*)(_root_.scala.sys.props.get("communitybuild.scala").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.scala'")))
-  val module3 = new MillCommunityBuildCross[mill.ModuleType]("2.13.8", "3.1.0")(_root_.scala.sys.props.get("communitybuild.scala").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.scala'"))){}
+  object module extends MillCommunityBuildCross[ModuleType]((Seq("2.13.8", "3.0.0") ++ Option("3.1.0")): _*)("3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD")
+  object module2 extends MillCommunityBuildCross[ModuleType]((Seq("2.13.8", "3.0.0") ++ Option("3.1.0")): _*)("3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD")
+  val module3 = new MillCommunityBuildCross[mill.ModuleType]("2.13.8", "3.1.0")("3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD"){}
+  object module4 extends MillCommunityBuildCross[ModuleType](versions:_*)("3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD")
+
 }

--- a/project-builder/mill/scalafix/output/src/main/scala/fix/MillPublishVersionOverride.scala
+++ b/project-builder/mill/scalafix/output/src/main/scala/fix/MillPublishVersionOverride.scala
@@ -2,15 +2,16 @@ package fix
 
 object MillPublishVersionOverride {
   final val Version = "3.1.1"
+  def T[U](v: U): U = ???
 
   object module {
-    val publishVersion = _root_.scala.sys.props.get("communitybuild.version").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.version'"))
+    val publishVersion = T{_root_.scala.sys.props.get("communitybuild.version").getOrElse("3.0.0")}
   }
   class moduleDef {
-    def publishVersion: String = _root_.scala.sys.props.get("communitybuild.version").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.version'"))
+    def publishVersion: String = T{_root_.scala.sys.props.get("communitybuild.version").getOrElse("3.0.1")}
   }
   class moduleDef2 extends moduleDef {
-    override val publishVersion: String = _root_.scala.sys.props.get("communitybuild.version").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.version'"))
+    override val publishVersion: String = T{_root_.scala.sys.props.get("communitybuild.version").getOrElse(MillPublishVersionOverride.Version)}
   }
 
   val snippet = s"""

--- a/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalaVersionOverride.scala
+++ b/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalaVersionOverride.scala
@@ -4,13 +4,13 @@ object MillScalaVersionOverride {
   def scala3Version = "3.1.1"
 
   object module {
-    val scalaVersion = _root_.scala.sys.props.get("communitybuild.scala").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.scala'"))
+    val scalaVersion = "3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD"
   }
   class moduleDef {
-    def scalaVersion: String = _root_.scala.sys.props.get("communitybuild.scala").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.scala'"))
+    def scalaVersion: String = "3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD"
   }
   class moduleDef2 extends moduleDef {
-    override val scalaVersion: String = _root_.scala.sys.props.get("communitybuild.scala").getOrElse(_root_.scala.sys.error("Missing required property 'communitybuild.scala'"))
+    override val scalaVersion: String = "3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD"
   }
 
   val snippet = s"""

--- a/project-builder/mill/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/project-builder/mill/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -4,6 +4,7 @@ import scalafix.testkit._
 import org.scalatest.FunSuiteLike
 
 class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
-  sys.props.update("scalafix.mill.skipHeader", "true")
+  sys.props.update("communitybuild.noInjects", "true")
+  sys.props.update("communitybuild.scala", "3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD")
   runAllTests()
 }

--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -80,7 +80,8 @@ object CommunityBuildPlugin extends AutoPlugin {
           publishResultsConf :=
             publishM2Configuration.value
               .withPublishMavenStyle(true)
-              .withResolverName(ourResolver.name),
+              .withResolverName(ourResolver.name)
+              .withOverwrite(true),
           publishResults := Classpaths.publishTask(publishResultsConf).value,
           externalResolvers := ourResolver +: externalResolvers.value
         )

--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -35,15 +35,12 @@ case class ModuleTargetsResults(
   }
 }
 case class ModuleBuildResults(
-    projectName: String, // Name of the project in the sbt build
-    organization: String,
-    artifactName: String, // Name of the artifact produced by build
+    artifactName: String,
     results: ModuleTargetsResults
 ) {
   lazy val toJson = {
     val resultsJson = results.jsonValues.mkString(", ")
-    val metadata = s""""meta": {"organization": "$organization" ,"projectName": "$projectName"}"""
-    s""""$artifactName": {$resultsJson, $metadata}"""
+    s""""$artifactName": {$resultsJson}"""
   }
 }
 
@@ -321,7 +318,6 @@ object CommunityBuildPlugin extends AutoPlugin {
         val evaluator = new TaskEvaluator(r, cState)
         val s = sbt.Project.extract(cState).structure
         val projectName = (r / moduleName).get(s.data).get
-        val orgName = (r / organization).get(s.data).get
 
         import evaluator._
         val results = {
@@ -340,9 +336,7 @@ object CommunityBuildPlugin extends AutoPlugin {
           )
         }
         ModuleBuildResults(
-          organization = orgName,
           artifactName = projectName,
-          projectName = r.project,
           results = results
         )
       }

--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -207,12 +207,13 @@ object CommunityBuildPlugin extends AutoPlugin {
           case projects =>
             projects
               .find(projectSupportsScalaBinaryVersion)
-              .getOrElse(
-                sys.error(
-                  s"Multiple targets found for ${target}, failed to select a single project that can be used with Scala ${scalaBinaryVersionUsed} in ${projects
-                    .map(_.project)}"
+              .getOrElse {
+                val selected = projects.head
+                System.err.println(
+                  s"None of projects in group ${projects.map(_.project)} uses current Scala binary version, using random: ${selected.project}"
                 )
-              )
+                selected
+              }
         }
       }
 

--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -135,7 +135,13 @@ object CommunityBuildPlugin extends AutoPlugin {
             val s = sbt.Project.extract(state).structure
             val projectVersion = (ref / Keys.version).get(s.data).get
             if (projectVersion == version) state
-            else Command.process(setVersionCmd(ref.project), state)
+            else
+              try Command.process(setVersionCmd(ref.project), state)
+              catch {
+                case ex: Exception =>
+                  System.err.println(s"Failed to set publish version in ${ref.project}, skipping")
+                  state
+              }
           }
       }
   }

--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -35,14 +35,14 @@ case class ModuleTargetsResults(
   }
 }
 case class ModuleBuildResults(
-    moduleName: String,
+    projectName: String, // Name of the project in the sbt build
     organization: String,
-    artifactName: String,
+    artifactName: String, // Name of the artifact produced by build
     results: ModuleTargetsResults
 ) {
   lazy val toJson = {
     val resultsJson = results.jsonValues.mkString(", ")
-    val metadata = s""""meta": {"organization": "$organization" ,"moduleName": "$moduleName"}"""
+    val metadata = s""""meta": {"organization": "$organization" ,"projectName": "$projectName"}"""
     s""""$artifactName": {$resultsJson, $metadata}"""
   }
 }
@@ -302,7 +302,7 @@ object CommunityBuildPlugin extends AutoPlugin {
           println(s"Starting build for $r...")
           val evaluator = new TaskEvaluator(r, cState)
           val s = sbt.Project.extract(cState).structure
-          val projectName = (r / normalizedName).get(s.data).get
+          val projectName = (r / moduleName).get(s.data).get
           val orgName = (r / organization).get(s.data).get
 
           import evaluator._
@@ -324,7 +324,7 @@ object CommunityBuildPlugin extends AutoPlugin {
           ModuleBuildResults(
             organization = orgName,
             artifactName = projectName,
-            moduleName = r.project,
+            projectName = r.project,
             results = results
           )
         }

--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -163,6 +163,13 @@ object CommunityBuildPlugin extends AutoPlugin {
           .mapValues(selectProject)
           .toMap
 
+        def simplifiedModuleId(id: String) =
+          // Drop first part of mapping (organization%)
+          id.substring(id.indexOf('%') + 1)
+        val simplifiedModuleIds = moduleIds.map { case (key, value) =>
+          simplifiedModuleId(key) -> value
+        }
+
         println("Starting build...")
 
         // Find projects that matches maven
@@ -175,10 +182,11 @@ object CommunityBuildPlugin extends AutoPlugin {
                 Seq("", scalaVersionSuffix, scalaBinaryVersionSuffix) ++
                   Option("Dotty").filter(_ => scalaBinaryVersionUsed.startsWith("3"))
               fullId = s"$id$suffix"
-            } yield Seq(
+            } yield Stream(
               refsByName.get(fullId),
               originalModuleIds.get(fullId),
-              moduleIds.get(fullId)
+              moduleIds.get(fullId),
+              simplifiedModuleIds.get(simplifiedModuleId(fullId))
             ).flatten
           } yield candidates.flatten.headOption.getOrElse {
             println("Module mapping missing:")

--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -1,20 +1,51 @@
 import sbt._
 import sbt.Keys._
 
-case class CommunityBuildCoverage(allDeps: Int, overridenScalaJars: Int, notOverridenScalaJars: Int)
+sealed abstract class BuildStepResult(val stringValue: String) {
+  def jsonValue = s""""$stringValue""""
+}
+sealed abstract class FailedBuildStep(name: String, info: List[(String, String)])
+    extends BuildStepResult(name) {
+  override def jsonValue =
+    if (info.isEmpty) s""""$name""""
+    else {
+      val infoFields = info.map { case (k, v) => s""""$k": "$v"""" }.mkString(", ")
+      s""""$name": {$infoFields}"""
+    }
+}
+case object Ok extends BuildStepResult("ok")
+case object Skipped extends BuildStepResult("skipped")
+case object Failed extends FailedBuildStep("failed", Nil)
+case class WrongVersion(expected: String, got: String)
+    extends FailedBuildStep("wrongVersion", List("expected" -> expected, "got" -> got))
+case class BuildError(msg: String) extends FailedBuildStep("buildError", List("reason" -> msg))
 
-abstract class BuildStepResult(val asString: String)
-
-case class Info(msg: String) extends BuildStepResult(s""""$msg"""")
-object CompileOk extends BuildStepResult(""""compile": "ok"""")
-object CompileFailed extends BuildStepResult(""""compile": "failed"""")
-object TestOk extends BuildStepResult(""""test": "ok"""")
-object TestFailed extends BuildStepResult(""""test": "failed"""")
-object PublishSkipped extends BuildStepResult(""""publish": "skipped"""")
-case class PublishWrongVersion(version: Option[String]) extends BuildStepResult(s""""publish": "wrongVersion=${version}"""")
-object PublishOk extends BuildStepResult(""""publish": "ok"""")
-object PublishFailed extends BuildStepResult(""""publish": "failed"""")
-case class BuildError(msg: String) extends BuildStepResult(s""""error": "${msg}"""")
+case class ModuleTargetsResults(
+    compile: BuildStepResult,
+    testsCompile: BuildStepResult,
+    publish: BuildStepResult
+) {
+  def hasFailedStep: Boolean = this.productIterator.exists(_.isInstanceOf[FailedBuildStep])
+  def jsonValues: List[String] = List(
+    "compile" -> compile,
+    "test-compile" -> testsCompile,
+    "publish" -> publish
+  ).map { case (key, value) =>
+    s""""$key": "${value.stringValue}""""
+  }
+}
+case class ModuleBuildResults(
+    moduleName: String,
+    organization: String,
+    artifactName: String,
+    results: ModuleTargetsResults
+) {
+  lazy val toJson = {
+    val resultsJson = results.jsonValues.mkString(", ")
+    val metadata = s""""meta": {"organization": "$organization" ,"moduleName": "$moduleName"}"""
+    s""""$artifactName": {$resultsJson, $metadata}"""
+  }
+}
 
 class ProjectBuildFailureException extends Exception
 
@@ -36,77 +67,89 @@ object CommunityBuildPlugin extends AutoPlugin {
   val moduleMappings = inputKey[Unit]("")
   val publishResults = taskKey[Unit]("")
   val publishResultsConf = taskKey[PublishConfiguration]("")
-  
+
   import complete.DefaultParsers._
-  
-  val ourResolver = "Community Build Repo" at sys.env("CB_MVN_REPO_URL")
 
-  override def projectSettings = Seq(
-    publishResultsConf := 
-      publishM2Configuration.value
-        .withPublishMavenStyle(true)
-        .withResolverName(ourResolver.name),
-    publishResults := Classpaths.publishTask(publishResultsConf).value,
-    externalResolvers := ourResolver +: externalResolvers.value
-  )
+  override def projectSettings =
+    sys.env
+      .get("CB_MVN_REPO_URL")
+      .filter(_.nonEmpty)
+      .map("Community Build Repo" at _)
+      .map { ourResolver =>
+        Seq(
+          publishResultsConf :=
+            publishM2Configuration.value
+              .withPublishMavenStyle(true)
+              .withResolverName(ourResolver.name),
+          publishResults := Classpaths.publishTask(publishResultsConf).value,
+          externalResolvers := ourResolver +: externalResolvers.value
+        )
+      }
+      .getOrElse(Nil)
 
-  private def stripScala3Suffix(s: String) = s match { case WithExtractedScala3Suffix(prefix, _) => prefix; case _ => s }
+  private def stripScala3Suffix(s: String) = s match {
+    case WithExtractedScala3Suffix(prefix, _) => prefix; case _ => s
+  }
 
-  /**
-   * Helper command used to set correct version for publishing Defined due to a
-   * bug in sbt which does not allow for usage of `set every` with scoped keys
-   * We need to use this task instead of `set every Compile/version := ???`,
-   * becouse it would set given value also in Jmh/version or Jcstress/version
-   * scopes, leading build failures
-   */
+  /** Helper command used to set correct version for publishing Defined due to a bug in sbt which
+    * does not allow for usage of `set every` with scoped keys We need to use this task instead of
+    * `set every Compile/version := ???`, becouse it would set given value also in Jmh/version or
+    * Jcstress/version scopes, leading build failures
+    */
   val setPublishVersion = Command.args("setPublishVersion", "<args>") { case (state, args) =>
     args.headOption
       .orElse(sys.props.get("communitybuild.version"))
+      .filter(_.nonEmpty)
       .fold {
         System.err.println("No explicit version found in setPublishVersion command, skipping")
         state
       } { version =>
         println(s"Setting publish version to $version")
 
-        val structure                      = sbt.Project.extract(state).structure
+        val structure = sbt.Project.extract(state).structure
         def setVersionCmd(project: String) = s"""set $project/version := "$version" """
 
-        structure.allProjectRefs.collect {
-          // Filter out root project, we need to use ThisBuild instead of root project name
-          case ref @ ProjectRef(uri, project) if structure.rootProject(uri) != project => ref
-        }.foldLeft(Command.process(setVersionCmd("ThisBuild"), state)) { case (state, ref) =>
-          // Check if project needs explicit overwrite, skip otherwise 
-          val s              = sbt.Project.extract(state).structure
-          val projectVersion = (ref / Keys.version).get(s.data).get
-          if (projectVersion == version) state
-          else Command.process(setVersionCmd(ref.project), state)
-        }
+        structure.allProjectRefs
+          .collect {
+            // Filter out root project, we need to use ThisBuild instead of root project name
+            case ref @ ProjectRef(uri, project) if structure.rootProject(uri) != project => ref
+          }
+          .foldLeft(Command.process(setVersionCmd("ThisBuild"), state)) { case (state, ref) =>
+            // Check if project needs explicit overwrite, skip otherwise
+            val s = sbt.Project.extract(state).structure
+            val projectVersion = (ref / Keys.version).get(s.data).get
+            if (projectVersion == version) state
+            else Command.process(setVersionCmd(ref.project), state)
+          }
       }
   }
 
   // Create mapping from org%artifact_name to project name
   val mkMappings = Def.task {
-     val cState = state.value
-      val s = sbt.Project.extract(cState).structure
-      val refs = s.allProjectRefs
-      refs.map { r =>
-        val current: ModuleID = (r / projectID).get(s.data).get
-        val sv = (r / scalaVersion).get(s.data).get
-        val sbv = (r / scalaBinaryVersion).get(s.data).get
-        val name = CrossVersion(current.crossVersion, sv, sbv)
-          .fold(current.name)(_(current.name))
-        val mappingKey = s"${current.organization}%${stripScala3Suffix(name)}"
-        mappingKey -> r
-      }
+    val cState = state.value
+    val s = sbt.Project.extract(cState).structure
+    val refs = s.allProjectRefs
+    refs.map { r =>
+      val current: ModuleID = (r / projectID).get(s.data).get
+      val sv = (r / scalaVersion).get(s.data).get
+      val sbv = (r / scalaBinaryVersion).get(s.data).get
+      val name = CrossVersion(current.crossVersion, sv, sbv)
+        .fold(current.name)(_(current.name))
+      val mappingKey = s"${current.organization}%${stripScala3Suffix(name)}"
+      mappingKey -> r
+    }
   }
 
-  lazy val ourVersion = 
+  lazy val ourVersion =
     Option(sys.props("communitybuild.version")).filter(_.nonEmpty)
 
   override def globalSettings = Seq(
     moduleMappings := { // Store settings in file to capture its original scala versions
       val moduleIds = mkMappings.value
-      IO.write(file("community-build-mappings.txt"), moduleIds.map(v => v._1 +" " +v._2.project).mkString("\n"))
+      IO.write(
+        file("community-build-mappings.txt"),
+        moduleIds.map(v => v._1 + " " + v._2.project).mkString("\n")
+      )
     },
     runBuild := {
       try {
@@ -136,7 +179,7 @@ object CommunityBuildPlugin extends AutoPlugin {
                 .startsWith(scalaBinaryVersionUsed)
             }
           // Workaround for scalatest/circe which does not set crossScalaVersions correctly
-          def matchesName = 
+          def matchesName =
             scalaBinaryVersionUsed.startsWith("3") && projectRef.project.contains("Dotty")
           hasCrossVersionSet || matchesName
         }
@@ -146,13 +189,20 @@ object CommunityBuildPlugin extends AutoPlugin {
           val target = projects.head._1
           projects.map(_._2) match {
             case Seq(project) => project
-            case projects => projects
-              .find(projectSupportsScalaBinaryVersion)
-              .getOrElse(sys.error(s"Multiple targets found for ${target}, failed to select a single project that can be used with Scala ${scalaBinaryVersionUsed} in ${projects.map(_.project)}"))
+            case projects =>
+              projects
+                .find(projectSupportsScalaBinaryVersion)
+                .getOrElse(
+                  sys.error(
+                    s"Multiple targets found for ${target}, failed to select a single project that can be used with Scala ${scalaBinaryVersionUsed} in ${projects
+                      .map(_.project)}"
+                  )
+                )
           }
         }
 
-        val originalModuleIds: Map[String, ProjectRef] =  IO.readLines(file("community-build-mappings.txt"))
+        val originalModuleIds: Map[String, ProjectRef] = IO
+          .readLines(file("community-build-mappings.txt"))
           .map(_.split(' '))
           .map(d => d(0) -> refsByName(d(1)))
           .groupBy(_._1)
@@ -189,24 +239,26 @@ object CommunityBuildPlugin extends AutoPlugin {
               simplifiedModuleIds.get(simplifiedModuleId(fullId))
             ).flatten
           } yield candidates.flatten.headOption.getOrElse {
-            println("Module mapping missing:")
-            println(s"id: $id")
-            println(s"actualId: $actualId")
-            println(s"scalaVersionSuffix: $scalaVersionSuffix")
-            println(s"scalaBinaryVersionSuffix: $scalaBinaryVersionSuffix")
-            println(s"refsByName: $refsByName")
-            println(s"originalModuleIds: $originalModuleIds")
-            println(s"moduleIds: $moduleIds")
+            println(s"""Module mapping missing:
+            |  id: $id
+            |  actualId: $actualId
+            |  scalaVersionSuffix: $scalaVersionSuffix
+            |  scalaBinaryVersionSuffix: $scalaBinaryVersionSuffix
+            |  refsByName: $refsByName
+            |  originalModuleIds: $originalModuleIds
+            |  moduleIds: $moduleIds
+            |""")
             throw new Exception("Module mapping missing")
-          
+
           }
         ).toSet
 
-        val projectDeps = s.allProjectPairs.map {case (rp, ref) =>
+        val projectDeps = s.allProjectPairs.map { case (rp, ref) =>
           ref -> rp.dependencies.map(_.project)
         }.toMap
 
-        @annotation.tailrec def flatten(soFar: Set[ProjectRef], toCheck: Set[ProjectRef]): Set[ProjectRef] =
+        @annotation.tailrec
+        def flatten(soFar: Set[ProjectRef], toCheck: Set[ProjectRef]): Set[ProjectRef] =
           toCheck match {
             case e if e.isEmpty => soFar
             case pDeps =>
@@ -215,81 +267,82 @@ object CommunityBuildPlugin extends AutoPlugin {
           }
 
         val allToBuild = flatten(topLevelProjects, topLevelProjects)
+        println("Projects: " + allToBuild.map(_.project))
 
-        println("Projects:")
-        println(allToBuild)
+        class TaskEvaluator(val project: ProjectRef, initialState: State) {
+          def eval(task: TaskKey[_]): BuildStepResult = {
+            try {
+              // we should reuse state here
+              sbt.Project
+                .runTask(project / task, initialState)
+                .fold[BuildStepResult](BuildError("Cannot eval command")) { case (_, result) =>
+                  result.toEither match {
+                    case Right(_) => Ok
+                    case Left(_)  => Failed
+                  }
+                }
+            } catch {
+              case ex: Exception =>
+                ex.printStackTrace()
+                BuildError(s"Evaluation error: ${ex.getMessage}")
+            }
+          }
+          def evalAsDependencyOf(
+              dependecyOf: => BuildStepResult
+          )(task: TaskKey[_]): BuildStepResult = {
+            dependecyOf match {
+              case _: FailedBuildStep => Skipped
+              case _                  => eval(task)
+            }
+          }
+        }
 
         val projectsBuildResults = allToBuild.map { r =>
           println(s"Starting build for $r...")
-          
-          val k = r / Compile / compile
-          // val t = r / Test / test
-          val t = r / Test / compile
+          val evaluator = new TaskEvaluator(r, cState)
+          val s = sbt.Project.extract(cState).structure
+          val projectName = (r / normalizedName).get(s.data).get
+          val orgName = (r / organization).get(s.data).get
 
-          // we should reuse state here
-
-          val res = List.newBuilder[BuildStepResult]
-          res += Info(r.project)
-
-          try {
-            sbt.Project.runTask(k, cState) match {
-              case Some((_, Value(_))) =>
-                res += CompileOk
-                sbt.Project.runTask(t, cState) match {
-                  case Some((_, Value(_))) => 
-                    res += TestOk
-                  case _ =>
-                    res += TestFailed
-                }
-
-                ourVersion match {
-                  case None =>
-                    res += PublishSkipped
-                  case Some(vo) =>
-                    val cv = (r / version).get(s.data)
-                    if (cv != Some(vo)){
-                      res += PublishWrongVersion(cv)
-                    } else {
-                      val p = r / Compile / publishResults
-                      sbt.Project.runTask(p, cState) match {
-                        case Some((_, Value(_))) => 
-                          res += PublishOk
-                        case _ =>
-                          res += PublishFailed
-                      }
-                    }
-                }
-              case _ =>
-                res += CompileFailed
-            } 
-          } catch {
-            case a: Throwable =>
-              a.printStackTrace()
-              res += BuildError(a.getMessage)
+          import evaluator._
+          val results = {
+            val compileResult = eval(Compile / compile)
+            ModuleTargetsResults(
+              compile = compileResult,
+              testsCompile = evalAsDependencyOf(compileResult)(Test / compile),
+              publish = ourVersion.fold[BuildStepResult](Skipped) { version =>
+                val currentVersion = (r / Keys.version)
+                  .get(s.data)
+                  .getOrElse(sys.error(s"${r.project}/version not set"))
+                if (currentVersion != version)
+                  WrongVersion(expected = version, got = currentVersion)
+                else evalAsDependencyOf(compileResult)(Compile / publishResults)
+              }
+            )
           }
-          res.result
+          ModuleBuildResults(
+            organization = orgName,
+            artifactName = projectName,
+            moduleName = r.project,
+            results = results
+          )
         }
-        val buildSummary = projectsBuildResults.map{
-          case subProjectName :: results => subProjectName.asString + ": " + results.map(_.asString).mkString("{", ", ", "}")
-          case List(s) => s.asString 
-        }.mkString("{", ", ", "}")
-        println("************************")
-        println("Build summary:")
-        println(buildSummary)
-        println("************************")
+        val buildSummary = projectsBuildResults
+          .map(_.toJson)
+          .mkString("{", ", ", "}")
+        println(s"""
+          |************************
+          |Build summary:
+          |${buildSummary}
+          |************************""".stripMargin)
         IO.write(file("..") / "build-summary.txt", buildSummary)
-        val failedSteps = projectsBuildResults.flatMap { results =>
-          results.collect {
-            case error @ (
-              CompileFailed | TestFailed | PublishWrongVersion(_) | PublishFailed | BuildError(_)
-            ) => error
-          }
-        }
-        val buildStatus = if (failedSteps.isEmpty) "success" else "failure"
+
+        val hasFailedSteps = projectsBuildResults.exists(_.results.hasFailedStep)
+        val buildStatus =
+          if (hasFailedSteps) "failure"
+          else "success"
         IO.write(file("..") / "build-status.txt", buildStatus)
-        if(failedSteps.nonEmpty) {
-          throw new ProjectBuildFailureException
-        }
+        if (hasFailedSteps) throw new ProjectBuildFailureException
       } catch {
         case a: Throwable =>
           a.printStackTrace()
@@ -297,5 +350,5 @@ object CommunityBuildPlugin extends AutoPlugin {
       }
     },
     (runBuild / aggregate) := false
-   )
+  )
 }

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -53,8 +53,7 @@ function runSbt(){
   fi
 
   sbt ${sbtSettings[@]} \
-    "show crossScalaVersions" \
-    "$setScalaVersionCmd" \
+    "$setScalaVersionCmd -v" \
     "setPublishVersion $version" \
     "set every credentials := Nil" \
     "$customCommands" \

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -63,7 +63,7 @@ function runSbt(){
 runSbt "no force" || {
   shouldRetry=0
   # Failed to switch version
-  if grep -q 'RuntimeException: Switch failed: no subproject' "$logFile"; then
+  if grep -q 'Switch failed:' "$logFile"; then
     shouldRetry=1
   # Incorrect mappings usng Scala 2.13
   elif grep -q 'Module mapping missing:' "$logFile" && grep -q -e 'moduleIds: .*_2\.1[1-3]' "$logFile"; then

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -40,7 +40,7 @@ sbtSettings=(
 customCommands=$(echo "$projectConfig" | jq -r '.sbt?.commands // [] | join ("; ")')
 targetsString="${targets[@]}"
 
-sbtClient="sbt --client --batch"
+sbtClient="sbt --client --batch --no-colors"
 $sbtClient ${sbtSettings[@]} "show crossScalaVersions"
 # Whenever possible don't force override Scala version
 # Some core modules (dependencies) might be only cross compiled for Scala 2.13

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -37,7 +37,6 @@ sbtSettings=(
   --batch
   --no-colors
   -Dcommunitybuild.version="$version"
-  "-J-Xmx4G"
   $(echo $projectConfig | jq -r '.sbt.options? // [] | join(" ")')
 )
 customCommands=$(echo "$projectConfig" | jq -r '.sbt?.commands // [] | join ("; ")')

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -6,10 +6,10 @@ if [ $# -ne 7 ]; then
   exit 1
 fi
 
-repoDir="$1" # e.g. /tmp/shapeless
-scalaVersion="$2" # e.g. 3.0.1-RC1-bin-COMMUNITY-SNAPSHOT
-version="$3" # e.g. 1.0.2-communityBuild
-unfilteredTargets="$4" # e.g. "com.example%foo com.example%bar"
+repoDir="$1"                # e.g. /tmp/shapeless
+scalaVersion="$2"           # e.g. 3.0.1-RC1-bin-COMMUNITY-SNAPSHOT
+version="$3"                # e.g. 1.0.2-communityBuild
+unfilteredTargets="$4"      # e.g. "com.example%foo com.example%bar"
 export CB_MVN_REPO_URL="$5" # e.g. https://mvn-repo/maven2/2021-05-23_1
 enforcedSbtVersion="$6"
 projectConfig="$7"
@@ -17,7 +17,7 @@ projectConfig="$7"
 targets=(${unfilteredTargets[@]})
 targetExcludeFilters=$(echo $projectConfig | jq -r '.projects?.exclude? // [] | join ("|")')
 if [ ! -z ${targetExcludeFilters} ]; then
-  targets=( $( for target in ${unfilteredTargets[@]} ; do echo $target ; done | grep -E -v "(${targetExcludeFilters})" ) )
+  targets=($(for target in ${unfilteredTargets[@]}; do echo $target; done | grep -E -v "(${targetExcludeFilters})"))
 fi
 
 echo '##################################'
@@ -27,10 +27,9 @@ echo Project projectConfig: $projectConfig
 echo '##################################'
 
 cd $repoDir
-
-sbtVersionSetting=""
 if [ -n "$enforcedSbtVersion" ]; then
-  sbtVersionSetting="--sbt-version $enforcedSbtVersion"
+  # Overwrite properties file, sbt thin client cannot take --sbt-version param
+  echo -e "sbt.version=$enforcedSbtVersion\n" >project/build.properties
 fi
 
 sbtSettings=(
@@ -41,11 +40,17 @@ sbtSettings=(
 customCommands=$(echo "$projectConfig" | jq -r '.sbt?.commands // [] | join ("; ")')
 targetsString="${targets[@]}"
 
+sbtClient="sbt --client --batch"
+$sbtClient ${sbtSettings[@]} "show crossScalaVersions"
+# Whenever possible don't force override Scala version
+# Some core modules (dependencies) might be only cross compiled for Scala 2.13
+$sbtClient "++$scalaVersion" || $sbtClient "++$scalaVersion!"
 # Use `setPublishVersion` instead of `every version`, as it might overrte Jmh/Jcstress versions
-sbt $sbtVersionSetting ${sbtSettings[@]} \
-  "++$scalaVersion"! \
-  "setPublishVersion $version" \
-  "set every credentials := Nil" \
-  "$customCommands" \
-  "moduleMappings" \
-  "runBuild $targetsString"
+$sbtClient "setPublishVersion $version"
+$sbtClient "set every credentials := Nil"
+if [ -n "$customCommands" ]; then
+  $sbtClient "$customCommands"
+fi
+$sbtClient "moduleMappings"
+$sbtClient "runBuild $targetsString"
+$sbtClient shutdown

--- a/project-builder/sbt/prepare-project.sh
+++ b/project-builder/sbt/prepare-project.sh
@@ -7,7 +7,7 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-repoDir="$1" # e.g. /tmp/shapeless
+repoDir="$1"            # e.g. /tmp/shapeless
 enforcedSbtVersion="$2" # e.g. '1.5.5' or empty ''
 
 # Check if using a sbt with a supported version
@@ -24,17 +24,17 @@ else
 fi
 
 function parseSemver() {
-  local prefixSufix=(`echo ${1/-/ }`)
+  local prefixSufix=($(echo ${1/-/ }))
   local prefix=${prefixSufix[0]}
   local suffix=${prefixSufix[1]}
-  local numberParts=(`echo ${prefix//./ }`)
+  local numberParts=($(echo ${prefix//./ }))
   local major=${numberParts[0]}
   local minor=${numberParts[1]}
   local patch=${numberParts[2]}
   echo "$major $minor $patch $suffix"
 }
 
-sbtSemVerParts=(`echo $(parseSemver "$sbtVersion")`)
+sbtSemVerParts=($(echo $(parseSemver "$sbtVersion")))
 sbtMajor=${sbtSemVerParts[0]}
 sbtMinor=${sbtSemVerParts[1]}
 sbtPatch=${sbtSemVerParts[2]}
@@ -44,9 +44,16 @@ if [ "$sbtMajor" -lt 1 ] || ([ "$sbtMajor" -eq 1 ] && [ "$sbtMinor" -lt 5 ]) || 
   exit 1
 fi
 
-scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 # Register command for setting up version, for more info check command impl comments
-echo -e "\ncommands += CommunityBuildPlugin.setPublishVersion\n" >> $repoDir/build.sbt
+echo -e "\ncommands += CommunityBuildPlugin.setPublishVersion\n" >>$repoDir/build.sbt
 
 ln -fs $scriptDir/CommunityBuildPlugin.scala $repoDir/project/CommunityBuildPlugin.scala
+
+# Project dependencies
+repoUrl=$(git remote get-url origin || echo "unknown")
+if [[ "$repoUrl" == *"shiftleftsecurity/codepropertygraph".git ]]; then
+  # https://github.com/shiftleftsecurity/codepropertygraph#building-the-code
+  git lfs pull
+fi

--- a/project-builder/sbt/prepare-project.sh
+++ b/project-builder/sbt/prepare-project.sh
@@ -48,5 +48,6 @@ scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Register command for setting up version, for more info check command impl comments
 echo -e "\ncommands += CommunityBuildPlugin.setPublishVersion\n" >> $repoDir/build.sbt
+echo -e "commands += CommunityBuildPlugin.setScalaVersion\n" >> $repoDir/build.sbt
 
 ln -fs $scriptDir/CommunityBuildPlugin.scala $repoDir/project/CommunityBuildPlugin.scala

--- a/project-builder/sbt/prepare-project.sh
+++ b/project-builder/sbt/prepare-project.sh
@@ -48,6 +48,5 @@ scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Register command for setting up version, for more info check command impl comments
 echo -e "\ncommands += CommunityBuildPlugin.setPublishVersion\n" >> $repoDir/build.sbt
-echo -e "commands += CommunityBuildPlugin.setScalaVersion\n" >> $repoDir/build.sbt
 
 ln -fs $scriptDir/CommunityBuildPlugin.scala $repoDir/project/CommunityBuildPlugin.scala

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -686,7 +686,7 @@ object MinikubeReproducer:
       tty = true,
       resources = ResourceRequirements(
         requests = Map("memory" -> Quantity("4Gi")),
-        limits = Map("memory" -> Quantity("6Gi"))
+        limits = Map("memory" -> Quantity("7Gi"))
       )
     )
 

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -1,0 +1,935 @@
+// Use Scala 3.0 until pretty stacktraces are fixed
+//> using scala "3.0.2"
+//> using lib "org.json4s::json4s-native:4.0.3"
+//> using lib "com.lihaoyi::requests:0.7.0"
+//> using lib "com.lihaoyi::os-lib:0.8.1"
+//> using lib "io.get-coursier:coursier_2.13:2.1.0-M5"
+//> using lib "com.goyeau::kubernetes-client:0.8.1"
+//> using lib "org.slf4j:slf4j-simple:1.6.4"
+//> using lib "com.github.scopt::scopt:4.0.1"
+
+import org.json4s.*
+import org.json4s.native.JsonMethods.*
+import org.json4s.JsonDSL.*
+import coursier.{parse => *, util => *, *}
+import scala.concurrent.*
+import scala.concurrent.duration.*
+import java.io.File
+
+import javax.net.ssl.SSLContext
+import coursier.cache.*
+
+import cats.Monad
+import cats.syntax.all.*
+import cats.effect.*
+import cats.effect.syntax.all.*
+import cats.effect.implicits.*
+import cats.effect.unsafe.IORuntime
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import com.goyeau.kubernetes.client.*
+import io.k8s.api.batch.v1.Job
+import Config.MinikubeConfig
+
+given Formats = DefaultFormats
+given ExecutionContext = ExecutionContext.Implicits.global
+
+class FailedProjectException(msg: String) extends RuntimeException(msg)
+
+private val CBRepoName = "VirtusLab/community-build3"
+val projectInfoerUrl = s"https://raw.githubusercontent.com/$CBRepoName/master/project-builder"
+val communityBuildRepo = s"https://github.com/$CBRepoName.git"
+
+case class Config(
+    jobId: String,
+    mode: Config.Mode = Config.Mode.Minikube,
+    scalaVersionOverride: Option[String] = None,
+    buildFailedModulesOnly: Boolean = false,
+    buildUpstream: Boolean = true,
+    jenkinsEndpoint: String = "https://scala3.westeurope.cloudapp.azure.com",
+    minikube: Config.MinikubeConfig = Config.MinikubeConfig()
+):
+  def jenkinsBuildProjectJob(jobId: String) = s"$jenkinsEndpoint/job/buildCommunityProject/$jobId"
+  def jenkinsRunBuildJob(jobId: String) = s"$jenkinsEndpoint/job/runBuild/$jobId"
+
+object Config:
+  enum Mode:
+    case Minikube, Local
+  case class MinikubeConfig(
+      keepCluster: Boolean = false,
+      keepMavenRepository: Boolean = false,
+      namespace: String = "scala3-community-build",
+      k8sConfig: File = (os.home / ".kube" / "config").toIO
+  )
+
+  val parser = {
+    import scopt.OParser
+    val builder = OParser.builder[Config]
+    import builder.*
+    OParser.sequence(
+      head("Scala 3 Community Build reproducer tool", "v0.0.4"),
+      opt[String]("jobId")
+        .required()
+        .action((x, c) => c.copy(jobId = x))
+        .text("Id of Jenkins 'buildCommunityProject' job to retry"),
+      opt[String]("scalaVersion")
+        .action((x, c) => c.copy(scalaVersionOverride = Some(x)))
+        .text("Scala version that should be used instead of the version used in the target build"),
+      opt[Unit]("failedTargetsOnly")
+        .action((x, c) => c.copy(buildFailedModulesOnly = true))
+        .text("Build only failed modules of target project"),
+      opt[Unit]("noBuildUpstream")
+        .action((x, c) => c.copy(buildUpstream = false))
+        .text("Build upstream projects of the target"),
+      opt[String]("jenkinsEndpoint")
+        .action((x, c) => c.copy(jenkinsEndpoint = x))
+        .text("Url of Jenkins instance to be used to gather build info instead of the default one")
+        .hidden(),
+      // Minikube speciifc
+      opt[Unit]("keepCluster")
+        .action((_, c) => c.copy(minikube = c.minikube.copy(keepCluster = true)))
+        .text("Should Minikube cluster be kept after finishing the build"),
+      opt[Unit]("keepMavenRepo")
+        .action((_, c) =>
+          c.copy(minikube = c.minikube.copy(keepCluster = true, keepMavenRepository = true))
+        )
+        .text("Should Maven repository instance be kept after finishing the build"),
+      opt[File]("k8sConfig")
+        .action((x, c) => c.copy(minikube = c.minikube.copy(k8sConfig = x)))
+        .text("Path to kubernetes config file, defaults to ~/.kube/config"),
+      // Modes
+      opt[Unit]("locally")
+        .action((_, c) => c.copy(mode = Mode.Local))
+        .text("Run build locally without minikube cluster")
+    )
+  }
+
+@main def reproduce(args: String*): Unit =
+  import Config.*
+  scopt.OParser
+    .parse(Config.parser, args, Config(jobId = ""))
+    .fold(()) { implicit config: Config =>
+      given build: BuildInfo = BuildInfo.fetchFromJenkins()
+
+      config.mode match {
+        case Mode.Minikube => MinikubeReproducer().run()
+        case Mode.Local    => LocalReproducer().run()
+      }
+    }
+
+case class ProjectInfo(id: String, params: BuildParameters, summary: BuildSummary) {
+  def projectName = params.projectName
+
+  def allDependencies(using build: BuildInfo): Set[ProjectInfo] =
+    val deps = params.upstreamProjects.flatMap { name =>
+      build.projectsByName.get(name).orElse {
+        // Can only happen if project was replayed - then upstream info would be empty
+        println(s"Not found upstream project $name in build info, it would be ignored")
+        None
+      }
+    }.toSet
+    val transtiveDeps = deps.flatMap(_.allDependencies)
+    transtiveDeps ++ deps
+
+  def buildPlanForDependencies(using BuildInfo): List[Set[ProjectInfo]] =
+    @scala.annotation.tailrec
+    def groupByDeps(
+        remaining: Set[ProjectInfo],
+        done: Set[String],
+        acc: List[Set[ProjectInfo]]
+    ): List[Set[ProjectInfo]] =
+      if remaining.isEmpty then acc.reverse
+      else
+        val (newRemainings, currentStep) = remaining
+          .partition(!_.params.upstreamProjects.forall(done.contains))
+        val names = currentStep.map(_.projectName)
+        groupByDeps(newRemainings, done ++ names, currentStep :: acc)
+    end groupByDeps
+    groupByDeps(allDependencies, Set.empty, Nil)
+  end buildPlanForDependencies
+}
+case class BuildInfo(projects: List[ProjectInfo]):
+  lazy val projectsByName = projects.map(p => p.projectName -> p).toMap
+  lazy val projectsById = projects.map(p => p.id -> p).toMap
+  // Following values are the same for all the projects
+  lazy val mavenRepositoryUrl = projectsById.head._2.params.mavenRepositoryUrl
+  def scalaVersion(using config: Config) = config.scalaVersionOverride
+    .getOrElse { projectsById.head._2.params.scalaVersion }
+
+object BuildInfo:
+  def fetchFromJenkins()(using config: Config): BuildInfo =
+    val jobId = config.jobId
+    println(s"Fetching build info from Jenkins based on project $jobId")
+    val runId = {
+      val r =
+        requests.get(s"${config.jenkinsBuildProjectJob(jobId)}/api/json?tree=actions[causes[*]]")
+      val json = parse(r.data.toString)
+      for {
+        JArray(ids) <- (json \ "actions" \ "causes" \ "upstreamBuild").toOption
+        JInt(id) <- ids.headOption
+      } yield id.toString
+    }
+
+    val runProjectIds = runId.fold {
+      println("No upstream project defined")
+      List(config.jobId)
+    } { runId =>
+      val r = requests.get(s"${config.jenkinsRunBuildJob(runId)}/consoleText")
+      val StartedProject = raw"Starting building: buildCommunityProject #(\d+)".r
+      new String(r.data.array).linesIterator
+        .collect { case StartedProject(id) => id }
+        .toList
+        .sorted
+    }
+
+    val getProjectsInfo = Future
+      .traverse(runProjectIds) { jobId =>
+        Future(BuildParameters.fetchFromJenkins(jobId))
+          .zip(Future(BuildSummary.fetchFromJenkins(jobId)))
+          .map(ProjectInfo(jobId, _, _))
+      }
+      .map(BuildInfo(_))
+
+    Await.result(getProjectsInfo, duration.Duration.Inf)
+
+end BuildInfo
+
+case class BuildSummary(projects: List[BuildProjectSummary]) {
+  lazy val failedTargets = projects.collect {
+    case BuildProjectSummary(organization, artifactName, _, results) if results.hasFailure =>
+      s"$organization%$artifactName"
+  }
+}
+object BuildSummary:
+  def fetchFromJenkins(jobId: String)(using config: Config): BuildSummary =
+    val r = requests.get(s"${config.jenkinsBuildProjectJob(jobId)}/artifact/build-summary.txt")
+    val projects = if !r.is2xx then
+      System.err.println(s"Failed to get build summary for job $jobId")
+      Nil
+    else
+      for
+        JObject(projects) <- parse(r.data.toString)
+        JField(artifactName, results: JObject) <- projects
+        JString(moduleName) <- results \ "meta" \ "moduleName"
+        JString(orgName) <- results \ "meta" \ "organization"
+        BuildResult(compile) <- results \ "compile"
+        BuildResult(testCompile) <- results \ "test-compile"
+      yield BuildProjectSummary(
+        organization = orgName,
+        artifactName = artifactName,
+        moduleName = moduleName,
+        results = ProjectTargetResults(
+          compile = compile,
+          testCompile = testCompile
+        )
+      )
+    BuildSummary(projects)
+
+case class BuildProjectSummary(
+    organization: String,
+    artifactName: String,
+    moduleName: String,
+    results: ProjectTargetResults
+)
+
+// Ignore publish step
+case class ProjectTargetResults(compile: BuildResult, testCompile: BuildResult) {
+  def hasFailure = productIterator.contains(BuildResult.Failed)
+}
+
+enum BuildResult:
+  case Ok, Skipped, Failed
+object BuildResult:
+  def unapply(value: JValue): Option[BuildResult] = value match {
+    case JString("ok")     => Some(BuildResult.Ok)
+    case JString("failed") => Some(BuildResult.Failed)
+    case JNothing          => Some(BuildResult.Skipped)
+    case _                 => None
+  }
+
+def gitCheckout(repoUrl: String, revision: Option[String])(cwd: os.Path): os.Path =
+  val repoDir = cwd
+  println(s"Checkout $repoUrl")
+  val projectDir = repoDir / "repo"
+  os.remove.all(projectDir)
+  val depth = revision.fold("--depth=1" :: Nil)(_ => Nil)
+  os
+    .proc("git", "clone", depth, repoUrl, projectDir.toString)
+    .call()
+  revision.foreach { rev =>
+    println(s"Setting project revision to $rev")
+    os.proc("git", "checkout", rev).call(cwd = projectDir)
+  }
+  projectDir
+
+class BuildParameters(params: Map[String, String]):
+  val projectName = params("projectName")
+  val projectConfig = params.get("projectConfig").filter(_.nonEmpty)
+  val projectReposiotryUrl = params("repoUrl")
+  val projectRevision = params.get("revision").filter(_.nonEmpty)
+  val projectVersion = params.get("version").filter(_.nonEmpty)
+
+  val scalaVersion = params("scalaVersion")
+  val jdkVersion = params.get("javaVersion").filter(_.nonEmpty)
+  val enforcedSbtVersion = params.get("enforcedSbtVersion").filter(_.nonEmpty)
+
+  val mavenRepositoryUrl = params("mvnRepoUrl")
+
+  val buildTargets = params("targets").split(' ').toList
+  val upstreamProjects = params("upstreamProjects").split(",").filter(_.nonEmpty).toList
+
+object BuildParameters:
+  def fetchFromJenkins(jobId: String)(using config: Config): BuildParameters =
+    val jobApi = s"${config.jenkinsBuildProjectJob(jobId)}/api"
+    val r =
+      requests.get(s"$jobApi/json?tree=actions[parameters[*]]")
+    val json = parse(r.data.toString)
+    val params = for {
+      JArray(params) <- json \ "actions" \ "parameters"
+      JObject(param) <- params
+      JField("name", JString(name)) <- param
+      JField("value", JString(value)) <- param
+    } yield name -> value
+    BuildParameters(params.toMap)
+
+private def checkRequiredApps(executables: String*): Unit =
+  val isWindows = sys.props("os.name").toLowerCase.startsWith("windows")
+  val which = if isWindows then "where" else "which"
+  val missing = executables.filterNot { name =>
+    val out = new String(os.proc(which, name).call(check = false).out.bytes)
+    out.linesIterator.filter(_.nonEmpty).hasNext
+  }.toList
+
+  if missing.nonEmpty then
+    System.err.println(
+      "Required programs are not installed or installed or set on PATH: " + missing.mkString(" ")
+    )
+    sys.exit(1)
+
+class MinikubeReproducer(using config: Config, build: BuildInfo):
+  checkRequiredApps("minikube", "kubectl")
+  def jobId = config.jobId
+  import MinikubeReproducer.*
+
+  private given k8s: MinikubeConfig = config.minikube
+  private given IORuntime = IORuntime.global
+
+  val communityBuildDir = gitCheckout(communityBuildRepo, None)(os.temp.dir())
+  private val scriptsDir = communityBuildDir / "scripts"
+  private val targetProject = build.projectsById(jobId)
+
+  private def localMavenUrl(using port: MavenForwarderPort) = {
+    build.mavenRepositoryUrl
+      .replace("https://mvn-repo:8081/maven2", s"https://localhost:$port/maven2")
+  }
+
+  def run(): Unit =
+    bash("minikube", "start", s"--namespace=${k8s.namespace}")
+    try
+      setupCluster()
+      usingMavenServiceForwarder {
+        usingUnsafeSSLContext {
+          given DependenciesChecker = DependenciesChecker(
+            checkLocalIvy = false,
+            extraRepositories = Seq(MavenRepository(localMavenUrl)),
+            fileCache = FileCache().noCredentials
+              .withHostnameVerifier(VerifiesAllHostNames)
+              .withSslSocketFactory(summon[SSLContext].getSocketFactory)
+          )
+          for {
+            logger <- Slf4jLogger.create[IO]
+            given Logger[IO] = logger
+            _ <- KubernetesClient(
+              KubeConfig.fromFile[IO](config.minikube.k8sConfig)
+            ).use { implicit k8sCLient: KubernetesClient[IO] =>
+              for {
+                _ <- logger.info("Starting")
+                _ <- buildScalaCompilerIfMissing[IO]()
+                _ <- buildProjectDependencies[IO]
+                _ <- buildMainProject[IO]
+                _ <- logger.info("Build finished")
+              } yield ()
+            }
+          } yield ()
+        }.unsafeRunSync()
+      }
+    finally
+      if !config.minikube.keepCluster then bash("minikube", "stop")
+      else
+        cleanCluster()
+        println("Keeping minikube alive, run 'minikube delete' to delete minikube local cluster")
+
+  private def setupCluster() =
+    bash(
+      "bash",
+      "-c",
+      s"kubectl create namespace ${k8s.namespace} --dry-run=client -o yaml | kubectl apply -f -"
+    )
+    // This is currently needed to handle broken certs if previous mvn-repo is still present
+    bash(scriptsDir / "stop-mvn-repo.sh")
+    bash(scriptsDir / "start-mvn-repo.sh")
+
+  private def cleanCluster()(using config: Config) =
+    if !config.minikube.keepMavenRepository
+    then bash(scriptsDir / "stop-mvn-repo.sh")
+
+  private def buildScalaCompilerIfMissing[F[_]: Async: Logger: KubernetesClient]()(using
+      checkDeps: DependenciesChecker
+  ): F[Unit] =
+    for
+      scalaReleaseExists <- Sync[F].blocking(checkDeps.scalaReleaseAvailable(build.scalaVersion))
+      _ <-
+        if !scalaReleaseExists then runJob[F](compilerBuilderJob).void
+        else Logger[F].info(s"Scala toolchain for version ${build.scalaVersion} already exists")
+    yield ()
+
+  private def buildProjectDependencies[F[_]: Async: Concurrent: Logger: KubernetesClient](using
+      build: BuildInfo,
+      config: Config
+  ) =
+    def buildDependenciesInGroup(group: Set[ProjectInfo]) =
+      group.toList.parTraverse { dependency =>
+        if config.buildFailedModulesOnly && dependency.summary.failedTargets.isEmpty then
+          Logger[F].info(s"Skip build for dependency ${dependency.projectName} - no failed targets")
+        else
+          Logger[F].info(s"Starting build dependency project ${dependency.projectName}") *>
+            runJob(projectBuilderJob(using dependency)).void
+      }
+
+    if !config.buildUpstream then Logger[F].info("Skipping building upstream projects")
+    else
+      for
+        buildPlan <- Sync[F].blocking(targetProject.buildPlanForDependencies.zipWithIndex)
+        _ <- buildPlan.traverse { (group, idx) =>
+          val projectsInGroup = group.map(_.params.projectName)
+          Logger[F].info(
+            s"Starting projects build for group ${idx + 1}/${buildPlan.length} with projects: $projectsInGroup "
+          ) *> buildDependenciesInGroup(group)
+        }
+      yield ()
+
+  private def buildMainProject[F[_]: Async: Logger: KubernetesClient] =
+    for {
+      _ <- Logger[F].info(
+        s"Starting build for target project $jobId (${targetProject.projectName})"
+      )
+      _ <- runJob(projectBuilderJob(using targetProject))
+    } yield ()
+
+  private def runJob[F[_]: Async: Logger](jobDefninition: Job)(using
+      k8sClient: KubernetesClient[F]
+  ): F[Int] =
+    val jobName = jobDefninition.metadata.flatMap(_.name).get
+    val selectorLabels = Map("job-name" -> jobName)
+    val jobsApi = k8sClient.jobs.namespace(k8s.namespace)
+    val podsApi = k8sClient.pods.namespace(k8s.namespace)
+    val logger = Logger[F]
+
+    def performCleanup = jobsApi.delete(jobName) *>
+      podsApi.deleteAll(selectorLabels) *>
+      podsApi.list(selectorLabels).iterateUntil(_.items.isEmpty)
+
+    def getContainerState = podsApi
+      .list(selectorLabels)
+      .delayBy(5.seconds)
+      .map { pods =>
+        for
+          pod <- pods.items.headOption // There should be only 1 job
+          status <- pod.status
+          // There should be only 1 container
+          containerStatus <- status.containerStatuses.flatMap(_.headOption)
+          containerState <- containerStatus.state
+        yield containerState
+      }
+      .iterateUntil(_.nonEmpty)
+      .map(_.get)
+
+    def waitForStart =
+      for
+        finalState <- getContainerState.iterateWhile { state =>
+          state.waiting.flatMap(_.reason) match {
+            case Some("ContainerCreating" | "ImagePullBackOff") => true
+            case _                                              => false
+          }
+        }
+        _ <-
+          if finalState.running.isDefined then Sync[F].pure(())
+          else Sync[F].raiseError(FailedProjectException(s"Failed to start pod of job ${jobName}"))
+      yield ()
+
+    def redirectLogsToFile = Sync[F].blocking {
+      val logsFile = os.temp(
+        prefix = s"cb-reproduce-log-$jobName",
+        deleteOnExit = false
+      )
+      // workaround, using os.PathRedirect to file was not working
+      Future {
+        val logs = os
+          .proc("kubectl", "-n", k8s.namespace, "logs", s"job/$jobName", "-f", "--timestamps=true")
+          .spawn()
+        val res = os.write.over(logsFile, logs.stdout)
+      }
+      logsFile
+    }
+    val projectRun =
+      for
+        _ <- performCleanup
+        job <- jobsApi.createWithResource(jobDefninition)
+        _ <- logger.info(s"Waiting for start of job $jobName")
+        _ <- waitForStart
+        _ <- logger.info(s"Pod for job $jobName started")
+
+        logsFile <- redirectLogsToFile
+        _ <- logger.info(s"Logs of job ${jobName} redirected to ${logsFile.toNIO.toAbsolutePath}")
+
+        exitCode <- getContainerState
+          .iterateUntil(_.terminated.isDefined)
+          .map(_.terminated.get.exitCode)
+          .timeout(30.minute)
+        _ <- logger.info(s"Job $jobName terminated with exit code $exitCode")
+
+        _ <- Sync[F].whenA(exitCode != 0) {
+          Sync[F].raiseError(FailedProjectException(s"Build failed for job ${jobName}"))
+        }
+      yield exitCode
+
+    projectRun
+      .onError(logger.error(_)(s"Failed to build project in job $jobName"))
+      .guarantee {
+        performCleanup
+          .onError(
+            logger
+              .error(_)(
+                s"Failed to delete job, use 'kubectl delete $jobName' to purge the resource'"
+              )
+          )
+          .void
+      }
+  end runJob
+
+  private def bash(args: os.Shellable*) =
+    os.proc(args)
+      .call(
+        stdout = os.Inherit,
+        stderr = os.Inherit,
+        env = Map("CB_K8S_NAMESPACE" -> k8s.namespace)
+      )
+
+object MinikubeReproducer:
+  opaque type MavenForwarderPort = Int
+  opaque type UnsafeSSLContext = javax.net.ssl.SSLContext
+
+  import io.k8s.api.core.v1.*
+  import io.k8s.api.batch.v1.*
+  import io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+
+  // Kubernetes API has A LOT of Options, simplify it locally
+  private given toSome[T]: Conversion[T, Option[T]] = Some(_)
+  import scala.language.implicitConversions
+
+  private val mvnRepoCrtSecret = "mvn-repo-cert"
+  private val mvnRepoCrt = "mvn-repo.crt"
+  private val imageVersion = "v0.0.4"
+
+  def usingMavenServiceForwarder[T](fn: MavenForwarderPort ?=> T)(using k8s: MinikubeConfig): T =
+    usingServiceForwarder("mvn-repo", 8081)(fn(using _))
+
+  def projectBuilderJob(using project: ProjectInfo, k8s: MinikubeConfig, config: Config): Job =
+    val params = project.params
+    val effectiveTargets =
+      if config.buildFailedModulesOnly then project.summary.failedTargets
+      else params.buildTargets
+    val effectiveScalaVersion = config.scalaVersionOverride
+      .getOrElse(params.scalaVersion)
+    Job(
+      metadata = ObjectMeta(name = s"build-project-${project.id}", namespace = k8s.namespace),
+      spec = JobSpec(
+        template = PodTemplateSpec(
+          metadata = ObjectMeta(
+            name = s"project-builder-${project.id}",
+            namespace = k8s.namespace
+          ),
+          spec = PodSpec(
+            volumes = Seq(mvnRepoSecretVolume),
+            containers = Seq(
+              builderContainer(
+                imageName = s"project-builder:jdk${params.jdkVersion.getOrElse("11")}-",
+                args = Seq(
+                  params.projectReposiotryUrl,
+                  params.projectRevision.getOrElse(""),
+                  effectiveScalaVersion,
+                  params.projectVersion.getOrElse(""),
+                  effectiveTargets.mkString(" "),
+                  params.mavenRepositoryUrl,
+                  params.enforcedSbtVersion.getOrElse(""),
+                  params.projectConfig.getOrElse("{}")
+                )
+              )
+            ),
+            restartPolicy = "Never"
+          )
+        ),
+        backoffLimit = 0
+      )
+    )
+
+  def compilerBuilderJob(using
+      k8s: MinikubeConfig,
+      build: BuildInfo,
+      config: Config
+  ): Job =
+    Job(
+      metadata = ObjectMeta(name = "build-compiler", namespace = k8s.namespace),
+      spec = JobSpec(
+        template = PodTemplateSpec(
+          metadata = ObjectMeta(
+            name = "compiler-builder",
+            namespace = k8s.namespace
+          ),
+          spec = PodSpec(
+            volumes = Seq(mvnRepoSecretVolume),
+            containers = Seq(
+              builderContainer(
+                imageName = "compiler-builder:",
+                args = Seq(
+                  "https://github.com/lampepfl/dotty.git",
+                  "main",
+                  build.scalaVersion,
+                  build.mavenRepositoryUrl
+                )
+              )
+            ),
+            restartPolicy = "Never"
+          )
+        ),
+        backoffLimit = 0
+      )
+    )
+
+  private val mvnRepoSecretVolume = Volume(
+    name = mvnRepoCrtSecret,
+    configMap = ConfigMapVolumeSource(name = mvnRepoCrtSecret)
+  )
+
+  private def builderContainer(imageName: String, args: Seq[String]) =
+    Container(
+      name = "builder",
+      image = s"virtuslab/scala-community-build-$imageName$imageVersion",
+      volumeMounts = Seq(
+        VolumeMount(
+          name = mvnRepoCrtSecret,
+          mountPath = s"/usr/local/share/ca-certificates/$mvnRepoCrt",
+          subPath = mvnRepoCrt,
+          readOnly = true
+        )
+      ),
+      // For some reason it seems to be broken
+      lifecycle =
+        Lifecycle(postStart = Handler(ExecAction(command = Seq("update-ca-certificates")))),
+      command = Seq("/build/build-revision.sh"),
+      args = args,
+      tty = true
+    )
+
+  import javax.net.ssl.*
+  import java.security.cert.X509Certificate
+  object VerifiesAllHostNames extends HostnameVerifier {
+    def verify(s: String, sslSession: SSLSession) = true
+  }
+
+  private lazy val unsafeSSLContext = {
+    object TrustAll extends X509TrustManager {
+      override def getAcceptedIssuers(): Array[X509Certificate] = Array()
+      override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String) = ()
+      override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String) = ()
+    }
+
+    val instance = SSLContext.getInstance("SSL")
+    instance.init(null, Array(TrustAll), new java.security.SecureRandom())
+    instance
+  }
+
+  def usingUnsafeSSLContext[T](fn: SSLContext ?=> T): T = {
+    def withDefault[In, Res](set: In => Unit, newValue: In, oldValue: In)(block: => Res) = {
+      set(newValue)
+      try block
+      finally set(oldValue)
+    }
+    withDefault(SSLContext.setDefault(_), unsafeSSLContext, SSLContext.getDefault) {
+      withDefault(
+        HttpsURLConnection.setDefaultSSLSocketFactory,
+        unsafeSSLContext.getSocketFactory,
+        HttpsURLConnection.getDefaultSSLSocketFactory
+      ) {
+        withDefault(
+          HttpsURLConnection.setDefaultHostnameVerifier,
+          VerifiesAllHostNames,
+          HttpsURLConnection.getDefaultHostnameVerifier
+        ) {
+          fn(using unsafeSSLContext)
+        }
+      }
+    }
+  }
+
+  private def usingServiceForwarder[T](serviceName: String, servicePort: Int)(fn: Int => T)(using
+      k8s: MinikubeConfig
+  ) =
+    val service = s"service/$serviceName"
+    val ForwardingLocallyOnPort = raw"Forwarding from 127.0.0.1:(\d+).*".r
+
+    val forwarder =
+      os.proc("kubectl", "-n", k8s.namespace, "port-forward", service, s":$servicePort").spawn()
+    try
+      forwarder.stdout.buffered.readLine match {
+        case ForwardingLocallyOnPort(port) =>
+          Future(forwarder.stdout.buffered.lines.forEach(println))
+          println(s"Forwarding $service on port ${port}")
+          val res = fn(port.toInt)
+          println("done")
+          res
+        case _ => sys.error(s"Failed to forward $service")
+      }
+    finally forwarder.destroy()
+
+class LocalReproducer(using config: Config, build: BuildInfo):
+  checkRequiredApps("scala-cli", "mill", "sbt", "git", "scala")
+
+  val dependencyChecker = DependenciesChecker(checkLocalIvy = true)
+
+  val effectiveScalaVersion = build.scalaVersion
+  val targetProject = build.projectsById(config.jobId)
+  private def effectiveTargets(using p: ProjectInfo) =
+    if config.buildFailedModulesOnly then p.summary.failedTargets
+    else p.params.buildTargets
+
+  def run(): Unit =
+    prepareScalaVersion()
+    if !config.buildUpstream then println("Skipping building upstream projects")
+    else
+      for
+        group <- targetProject.buildPlanForDependencies
+        dep <- group
+      do buildProject(dep)
+    buildProject(targetProject)
+
+  private def buildProject(project: ProjectInfo) =
+    println(s"Building project ${project.id} (${project.projectName})")
+    given ProjectInfo = project
+    val projectDir = gitCheckout(
+      targetProject.params.projectReposiotryUrl,
+      targetProject.params.projectRevision
+    )(os.pwd)
+    val impl =
+      if os.exists(projectDir / "build.sbt") then SbtReproducer(projectDir)
+      else if os.exists(projectDir / "build.sc") then MillReproducer(projectDir)
+      else sys.error("Unsupported build tool")
+    impl.prepareBuild()
+    impl.runBuild()
+
+  private def prepareScalaVersion(): Unit =
+    val needsCompilation = !dependencyChecker.scalaReleaseAvailable(effectiveScalaVersion)
+
+    if needsCompilation then
+      println(s"Building Scala compiler for version $effectiveScalaVersion")
+      val VersionCommitSha = raw"3\..*-bin-([0-9a-f]*)-.*".r
+      val revision = effectiveScalaVersion match {
+        case VersionCommitSha(revision) => Some(revision)
+        case _                          => None
+      }
+      val projectDir = gitCheckout("https://github.com/lampepfl/dotty.git", revision)(os.temp.dir())
+
+      // Overwrite compiler baseVersion
+      val buildFile = projectDir / "project" / "Build.scala"
+      val updatedBuild =
+        os.read(buildFile).replaceAll("(val baseVersion) = .*", s"$$1 = \"$effectiveScalaVersion\"")
+      os.write.over(buildFile, updatedBuild)
+      println("Building Scala...")
+      os
+        .proc("sbt", "scala3-bootstrapped/publishLocal")
+        .call(
+          cwd = projectDir,
+          env = Map("RELEASEBUILD" -> "yes"),
+          stdout = os.Inherit,
+          stderr = os.Inherit
+        )
+      println(s"Scala ${effectiveScalaVersion} was successfully published locally")
+  end prepareScalaVersion
+
+  // Build reproducer impls
+  abstract class BuildToolReproducer:
+    def prepareBuild(): Unit
+    def runBuild(): Unit
+    def onFailure(v: BuildResult)(ret: => String): Option[String] =
+      v match {
+        case BuildResult.Failed => Some(ret)
+        case _                  => None
+      }
+
+  class SbtReproducer(projectDir: os.Path)(using
+      projectCtx: ProjectInfo,
+      build: BuildInfo
+  ) extends BuildToolReproducer:
+    val buildParams = projectCtx.params
+    case class SbtConfig(options: List[String], commands: List[String])
+    given Manifest[SbtConfig] = scala.reflect.Manifest.classType(classOf[SbtConfig])
+    val CBPluginFile = "CommunityBuildPlugin.scala"
+    val minSbtVersion = "1.5.5"
+    val defaultSettings = Seq("-J-Xmx4G")
+    val sbtConfig = buildParams.projectConfig
+      .map(parse(_) \ "sbt")
+      .flatMap(_.extractOpt[SbtConfig])
+      .getOrElse(SbtConfig(Nil, Nil))
+    val sbtSettings = defaultSettings ++ sbtConfig.options
+    val sbtBuildProperties = projectDir / "project" / "build.properties"
+
+    // Assumes build.propeties contains only sbt.version
+    val currentSbtVersion = os.read(sbtBuildProperties).trim.stripPrefix("sbt.version=")
+    val belowMinimalSbtVersion = currentSbtVersion.split('.').take(3).map(_.toInt) match {
+      case Array(1, minor, patch) => minor < 5 || patch < 5
+      case _                      => false
+    }
+
+    override def prepareBuild(): Unit =
+      val communityBuild = gitCheckout(communityBuildRepo, None)(os.temp.dir())
+      val projectInfoer = communityBuild / "project-builder"
+
+      buildParams.enforcedSbtVersion match {
+        case Some(version) => os.write.over(sbtBuildProperties, s"sbt.version=$version")
+        case _ =>
+          if belowMinimalSbtVersion then
+            println(
+              s"Overwritting sbt version $currentSbtVersion with minimal supported version $minSbtVersion"
+            )
+            os.write.over(sbtBuildProperties, s"sbt.version=$minSbtVersion")
+      }
+      os.copy.into(
+        projectInfoer / "sbt" / CBPluginFile,
+        projectDir / "project",
+        replaceExisting = true
+      )
+
+    override def runBuild(): Unit =
+      try
+        try sbtClient(s"++${effectiveScalaVersion}")
+        catch case ex: Exception => sbtClient(s"++${effectiveScalaVersion}!")
+        sbtClient("set every credentials := Nil")
+        sbtClient("moduleMappings")
+        sbtClient(sbtConfig.commands)
+        sbtClient("runBuild", effectiveTargets)
+      catch {
+        case ex: Exception => System.err.println("Failed to run the build, check logs for details.")
+      } finally sbtClient("shutdown")
+
+    private def sbtClient(commands: os.Shellable*): os.CommandResult =
+      os.proc("sbt", "--client", "--batch", sbtSettings, commands)
+        .call(
+          cwd = projectDir,
+          stdin = os.Inherit,
+          stdout = os.Inherit,
+          env = Map("CB_MVN_REPO_URL" -> "")
+        )
+
+  end SbtReproducer
+
+  class MillReproducer(projectDir: os.Path)(using
+      projectCtx: ProjectInfo,
+      build: BuildInfo
+  ) extends BuildToolReproducer:
+    val MillCommunityBuildSc = "MillCommunityBuild.sc"
+    val millScalaSetting = List(
+      "-D",
+      s"communitybuild.scala=${effectiveScalaVersion}"
+    )
+    val scalafixRulePath = "scalafix/rules/src/main/scala/fix/Scala3CommunityBuildMillAdapter.scala"
+    val scalafixSettings = List(
+      "--stdout",
+      "--syntactic",
+      "--scala-version=3.1.0"
+    )
+    override def prepareBuild(): Unit =
+      val communityBuild = gitCheckout(communityBuildRepo, None)(os.temp.dir())
+      val projectInfoer = communityBuild / "project-builder"
+      val millBuilder = projectInfoer / "mill"
+      val buildFile = projectDir / "build.sc"
+      val buildFileCopy = projectDir / "build.scala"
+
+      val scalafixClasspath = coursier
+        .Fetch()
+        .addDependencies(
+          coursier.Dependency(
+            Module(Organization("ch.epfl.scala"), ModuleName("scalafix-cli_2.13.8")),
+            "0.9.34"
+          )
+        )
+        .run
+        .mkString(java.io.File.pathSeparator)
+
+      os.copy.over(buildFile, buildFileCopy)
+      os.proc(
+        "java",
+        "-cp",
+        scalafixClasspath,
+        millScalaSetting.mkString,
+        "scalafix.v1.Main",
+        s"--rules=file:${millBuilder}/$scalafixRulePath",
+        s"--files=${buildFileCopy}",
+        scalafixSettings
+      ).call(cwd = projectDir, stdout = os.PathRedirect(buildFile))
+      os.remove(buildFileCopy)
+      os.copy.into(millBuilder / MillCommunityBuildSc, projectDir, replaceExisting = true)
+
+    override def runBuild(): Unit =
+      def mill(commands: os.Shellable*) =
+        os.proc("mill", millScalaSetting, commands).call(cwd = projectDir, stdout = os.Inherit)
+      val scalaVersion = Seq("--scalaVersion", effectiveScalaVersion)
+      mill("runCommunityBuild", scalaVersion, effectiveTargets)
+  end MillReproducer
+end LocalReproducer
+
+case class Dependency(org: String, name: String, version: String)
+class DependenciesChecker(
+    checkLocalIvy: Boolean = true,
+    extraRepositories: Seq[Repository] = Nil,
+    fileCache: Cache[coursier.util.Task] = Cache.default
+):
+  def checkDependenciesExist(dependencies: Dependency*) =
+    import scala.util.Try
+    // If dependency does not exists it would throw exception
+    // By default coursier checks `.ivy2/local` (publishLocal target) and Maven repo
+    val coursierDeps =
+      for Dependency(org, name, version) <- dependencies
+      yield coursier.Dependency(Module(Organization(org), ModuleName(name)), version)
+
+    Try {
+      val defaultInstance = coursier
+        .Resolve()
+        .withCache(fileCache)
+        .addRepositories(extraRepositories: _*)
+        .addDependencies(coursierDeps: _*)
+      val instance =
+        if checkLocalIvy then defaultInstance
+        else
+          defaultInstance.withRepositories(
+            defaultInstance.repositories.filter(!_.repr.startsWith("ivy:file:"))
+          )
+      instance.run()
+    }.isSuccess
+
+  def scalaReleaseAvailable(
+      scalaVersion: String,
+      extraRepositories: Seq[Repository] = Nil
+  ): Boolean =
+    val deps =
+      for name <- Seq(
+          "scala3-library",
+          "scala3-compiler",
+          "scala3-language-server",
+          "scala3-staging",
+          "scala3-tasty-inspector",
+          "scaladoc",
+          "tasty-core"
+        ).map(_ + "_3") ++ Seq("scala3-interfaces", "scala3-sbt-bridge")
+      yield Dependency("org.scala-lang", name, scalaVersion)
+    checkDependenciesExist(deps: _*)
+end DependenciesChecker

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -893,8 +893,7 @@ class LocalReproducer(using config: Config, build: BuildInfo):
         os.proc(
           "sbt",
           "--no-colors",
-          "show crossScalaVersions",
-          s"++$effectiveScalaVersion$versionSwitchSuffix",
+          s"++$effectiveScalaVersion$versionSwitchSuffix -v",
           "set every credentials := Nil",
           "moduleMappings",
           sbtConfig.commands,

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -767,7 +767,7 @@ class LocalReproducer(using config: Config, build: BuildInfo):
       project.params.projectReposiotryUrl,
       project.params.projectRevision
     )(os.pwd)
-    val logsFile = os.temp(prefix = s"cb-logs-build-project-${project.id}")
+    val logsFile = os.temp(prefix = s"cb-logs-build-project-${project.id}", deleteOnExit = false)
     val impl =
       if os.exists(projectDir / "build.sbt") then SbtReproducer(projectDir, logsFile)
       else if os.exists(projectDir / "build.sc") then MillReproducer(projectDir, logsFile)
@@ -787,7 +787,7 @@ class LocalReproducer(using config: Config, build: BuildInfo):
 
     if !needsCompilation then println(s"Scala ${effectiveScalaVersion} toolchain already present")
     else
-      val logsFile = os.temp("cb-build-compiler")
+      val logsFile = os.temp("cb-build-compiler", deleteOnExit = false)
       println(
         s"Building Scala compiler for version $effectiveScalaVersion, logs redirected to $logsFile"
       )
@@ -993,7 +993,9 @@ class DependenciesChecker(
       val expectedModules = coursierDeps.map(_.module)
       !err.errors.exists {
         case err: ResolutionError.CantDownloadModule => expectedModules.contains(err.module)
-        case _                                       => false
+        case _ =>
+          System.err.println(err)
+          false
       }
     instance
       .withDependencies(coursierDeps)

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -261,7 +261,7 @@ def gitCheckout(repoUrl: String, revision: Option[String])(cwd: os.Path): os.Pat
   os.remove.all(projectDir)
   val depth = revision.fold("--depth=1" :: Nil)(_ => Nil)
   os
-    .proc("git", "clone", depth, repoUrl, projectDir.toString)
+    .proc("git", "clone", "--quiet", depth, repoUrl, projectDir.toString)
     .call(stderr = os.Pipe)
   revision.foreach { rev =>
     println(s"Setting project revision to $rev")

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -365,8 +365,6 @@ class MinikubeReproducer(using config: Config, build: BuildInfo):
       "-c",
       s"kubectl create namespace ${k8s.namespace} --dry-run=client -o yaml | kubectl apply -f -"
     )
-    // This is currently needed to handle broken certs if previous mvn-repo is still present
-    bash(scriptsDir / "stop-mvn-repo.sh")
     bash(scriptsDir / "start-mvn-repo.sh")
 
   private def cleanCluster()(using config: Config) =

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -891,7 +891,7 @@ class LocalReproducer(using config: Config, build: BuildInfo):
       } finally sbtClient("shutdown")
 
     private def sbtClient(commands: os.Shellable*): os.CommandResult =
-      os.proc("sbt", "--client", "--batch", commands)
+      os.proc("sbt", "--client", "--batch", "--no-colors", commands)
         .call(
           cwd = projectDir,
           stdout = os.PathAppendRedirect(logsFile),

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -528,7 +528,7 @@ class MinikubeReproducer(using config: Config, build: BuildInfo):
         exitCode <- getContainerState
           .iterateUntil(_.terminated.isDefined)
           .map(_.terminated.get.exitCode)
-          .timeout(30.minute)
+          .timeout(60.minute)
         _ <- logger.info(s"Job $jobName ($label) terminated with exit code $exitCode")
 
         _ <- Sync[F].whenA(exitCode != 0) {

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -850,12 +850,11 @@ class LocalReproducer(using config: Config, build: BuildInfo):
     given Manifest[SbtConfig] = scala.reflect.Manifest.classType(classOf[SbtConfig])
     val CBPluginFile = "CommunityBuildPlugin.scala"
     val minSbtVersion = "1.5.5"
-    val defaultSettings = Seq("-J-Xmx4G")
     val sbtConfig = project.params.projectConfig
       .map(parse(_) \ "sbt")
       .flatMap(_.extractOpt[SbtConfig])
       .getOrElse(SbtConfig(Nil, Nil))
-    val sbtSettings = defaultSettings ++ sbtConfig.options
+    val sbtSettings = sbtConfig.options
     val sbtBuildProperties = projectDir / "project" / "build.properties"
 
     val currentSbtVersion = os

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -217,14 +217,14 @@ object BuildSummary:
       for
         JObject(projects) <- parse(r.data.toString)
         JField(artifactName, results: JObject) <- projects
-        JString(moduleName) <- results \ "meta" \ "moduleName"
+        JString(projectName) <- results \ "meta" \ "projectName"
         JString(orgName) <- results \ "meta" \ "organization"
         BuildResult(compile) <- results \ "compile"
         BuildResult(testCompile) <- results \ "test-compile"
       yield BuildProjectSummary(
         organization = orgName,
         artifactName = artifactName,
-        moduleName = moduleName,
+        projectName = projectName,
         results = ProjectTargetResults(
           compile = compile,
           testCompile = testCompile
@@ -234,8 +234,8 @@ object BuildSummary:
 
 case class BuildProjectSummary(
     organization: String,
-    artifactName: String,
-    moduleName: String,
+    artifactName: String, // Name of the created artifact
+    projectName: String,  // Name of the project within the build
     results: ProjectTargetResults
 )
 

--- a/project-reproducer/reproducer.scala
+++ b/project-reproducer/reproducer.scala
@@ -327,7 +327,7 @@ class MinikubeReproducer(using config: Config, build: BuildInfo):
     build.mavenRepositoryUrl
       .replace(
         "https://mvn-repo:8081/maven2",
-        s"https://localhost:$port/maven2/${build.scalaVersion}"
+        s"https://localhost:$port/maven2/"
       )
   }
 

--- a/scripts/prepare-local-deployment.sh
+++ b/scripts/prepare-local-deployment.sh
@@ -2,5 +2,11 @@
 set -e
 
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+k8sAuth=$scriptDir/../k8s/auth
+
 
 $scriptDir/start-jenkins-operator.sh
+
+source $scriptDir/utils.sh
+scbk apply -f $k8sAuth/githubOAuthSecret.yaml
+scbk apply -f $k8sAuth/authz-matrix.yaml

--- a/scripts/start-elastic.sh
+++ b/scripts/start-elastic.sh
@@ -4,6 +4,7 @@ set -e
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $scriptDir/utils.sh
 
-kubectl apply -f https://download.elastic.co/downloads/eck/1.6.0/all-in-one.yaml
+kubectl create -f https://download.elastic.co/downloads/eck/2.0.0/crds.yaml
+kubectl apply -f https://download.elastic.co/downloads/eck/2.0.0/operator.yaml
 
 scbk apply -f k8s/elastic.yaml

--- a/scripts/start-mvn-repo.sh
+++ b/scripts/start-mvn-repo.sh
@@ -4,12 +4,14 @@ set -e
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $scriptDir/utils.sh
 
-export MVN_REPO_KEYSTORE_PASSWORD=$(openssl rand -base64 32)
+if [ -z "$MVN_REPO_KEYSTORE_PASSWORD" ];then
+  export MVN_REPO_KEYSTORE_PASSWORD=$(openssl rand -base64 32)
+fi
 
 $scriptDir/generate-secrets.sh
 
-scbk create secret generic mvn-repo-keystore --from-file=$scriptDir/../secrets/mvn-repo.p12
-scbk create secret generic mvn-repo-passwords --from-literal=keystore-password="$MVN_REPO_KEYSTORE_PASSWORD"
-scbk create cm mvn-repo-cert --from-file=$scriptDir/../secrets/mvn-repo.crt
+scbk create secret generic mvn-repo-keystore --from-file=$scriptDir/../secrets/mvn-repo.p12 -o yaml --dry-run=client | kubectl apply -f -
+scbk create secret generic mvn-repo-passwords --from-literal=keystore-password="$MVN_REPO_KEYSTORE_PASSWORD" -o yaml --dry-run=client | kubectl apply -f -
+scbk create cm mvn-repo-cert --from-file=$scriptDir/../secrets/mvn-repo.crt -o yaml --dry-run=client | kubectl apply -f -
 scbk apply -f $scriptDir/../k8s/mvn-repo-data.yaml
 scbk apply -f $scriptDir/../k8s/mvn-repo.yaml

--- a/scripts/start-mvn-repo.sh
+++ b/scripts/start-mvn-repo.sh
@@ -4,9 +4,7 @@ set -e
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $scriptDir/utils.sh
 
-if [ -z "$MVN_REPO_KEYSTORE_PASSWORD" ];then
-  export MVN_REPO_KEYSTORE_PASSWORD=$(openssl rand -base64 32)
-fi
+export MVN_REPO_KEYSTORE_PASSWORD=$(openssl rand -base64 32)
 
 $scriptDir/generate-secrets.sh
 


### PR DESCRIPTION
This PR adds a scala-cli based script that can snip up the project builds locally or in minikube instance based on the information fetched from Jenkins. Upon failure of the project build in the Jenkins logs would contain a command that can be used to run scala-cli script.  

* Added initial reproducer script with minikube and local build supports
* Updated base version of images to 0.0.4 
* Fixed issues with computing build plan after scaladex recent changes
* Always perform full clone of the repo (due to problems with dynver) 
* Add git-lfs to builder images (one of the projects dependency)
* Don't force scalaVersion (fixes issues with some of the builds)
* Don't require CB_MVN_REPO_URL env variable 
* Increase limit of memory in kubernetes jobs to 7Gb 
* Fix scalafix mill override rules (due to discovered bugs)
* Update bash scripts