### PR TITLE
Rewrite mill publishVersion with fixed version

### DIFF
--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -1109,7 +1109,9 @@ class LocalReproducer(using config: Config, build: BuildInfo):
     val scalafixSettings = List(
       "--stdout",
       "--syntactic",
-      "--scala-version=3.1.0"
+      "--scala-version=3.1.0",
+      "--settings.Scala3CommunityBuildMillAdapter.targetScalaVersion", effectiveScalaVersion,
+      "--settings.Scala3CommunityBuildMillAdapter.targetPublishVersion", project.params.version.getOrElse("")
     )
     override def prepareBuild(): Unit =
       val millBuilder = projectBuilderDir / "mill"

--- a/project-builder/mill/prepare-project.sh
+++ b/project-builder/mill/prepare-project.sh
@@ -22,6 +22,7 @@ cp repo/build.sc repo/build.scala \
     --stdout \
     --syntactic \
     --settings.Scala3CommunityBuildMillAdapter.targetScalaVersion "$scalaVersion" \
+    --settings.Scala3CommunityBuildMillAdapter.targetPublishVersion "$publishVersion" \
     --scala-version 3.1.0 > repo/build.sc \
   && rm repo/build.scala 
 

--- a/project-builder/mill/scalafix/output/src/main/scala/fix/MillPublishVersionOverride.scala
+++ b/project-builder/mill/scalafix/output/src/main/scala/fix/MillPublishVersionOverride.scala
@@ -5,13 +5,13 @@ object MillPublishVersionOverride {
   def T[U](v: U): U = ???
 
   object module {
-    val publishVersion = T{_root_.scala.sys.props.get("communitybuild.version").getOrElse("3.0.0")}
+    val publishVersion = "1.2.3-RC4"
   }
   class moduleDef {
-    def publishVersion: String = T{_root_.scala.sys.props.get("communitybuild.version").getOrElse("3.0.1")}
+    def publishVersion: String = "1.2.3-RC4"
   }
   class moduleDef2 extends moduleDef {
-    override val publishVersion: String = T{_root_.scala.sys.props.get("communitybuild.version").getOrElse(MillPublishVersionOverride.Version)}
+    override val publishVersion: String = "1.2.3-RC4"
   }
 
   val snippet = s"""

--- a/project-builder/mill/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/project-builder/mill/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -6,5 +6,6 @@ import org.scalatest.FunSuiteLike
 class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
   sys.props.update("communitybuild.noInjects", "true")
   sys.props.update("communitybuild.scala", "3.1.2-RC2-bin-cb00abcdef123456789-COMMUNITY-BUILD")
+  sys.props.update("communitybuild.version", "1.2.3-RC4")
   runAllTests()
 }


### PR DESCRIPTION
This PR changes the method how scalafix rules are being applied. Now publishVersion in mill is being rewritten using constant string value, instead of value resolved from system properties. It now follows rewrites of scalaVersion in mill builds.