### PR TITLE
By default use sbt 1.6.2 in 'runBuild' job

### DIFF
--- a/jenkins/seeds/initializeSeedJobs.groovy
+++ b/jenkins/seeds/initializeSeedJobs.groovy
@@ -55,7 +55,7 @@ pipelineJob('/runBuild') {
             separatorStyle("")
             sectionHeaderStyle("")
         }
-        stringParam("enforcedSbtVersion", null, "(Optional): When not specified original sbt versions specified in the build definition of each project will be used")
+        stringParam("enforcedSbtVersion", "1.6.2", "(Optional): When not specified original sbt versions specified in the build definition of each project will be used")
         separator {
             name("GENERAL")
             sectionHeader("General")


### PR DESCRIPTION
This PR sets a enforces usage of sbt 1.6.2 by default in all sbt projects executed in `runBuild` job. This is needed, since many projects are still stuck on sbt older than 1.5.4 which is not supported. 1.6.x series also fixes some of the builds problems. 