### PR TITLE
Improve selection of project version used for the build

### DIFF
--- a/coordinator/src/main/resources/buildPlan.reference.conf
+++ b/coordinator/src/main/resources/buildPlan.reference.conf
@@ -21,6 +21,8 @@ java {
 
 mill {
    // Options that would passed to the mill instance when starting
+   // Can one of available (enquoted in <>) variables that would be replaced before passing to the build tool:
+   // * SCALA_VERSION - Scala version that would be used to run the build, eg. -Dcurrent.scala=<SCALA_VERSION> 
   options = []
 }
 
@@ -30,5 +32,7 @@ sbt {
   commands = []
 
    // Options that would passed to the sbt instance when starting, should start with `-D`, `-J` or `-S`
+   // Can one of available (enquoted in <>) variables that would be replaced before passing to the build tool:
+   // * SCALA_VERSION - Scala version that would be used to run the build, eg. -Dcurrent.scala=<SCALA_VERSION>
   options = []
 }

--- a/coordinator/src/main/scala/deps.scala
+++ b/coordinator/src/main/scala/deps.scala
@@ -75,8 +75,12 @@ def asTarget(scalaBinaryVersion: String)(mv: ModuleVersion): Target =
   Target(TargetId(o,n), deps.toSeq)
 
 def loadMavenInfo(scalaBinaryVersion: String)(projectModules: ProjectModules): LoadedProject = 
+  import projectModules.project.{name, org}
+  val repoName = s"https://github.com/$org/$name.git" 
   require(projectModules.mvs.nonEmpty, s"Empty modules list in ${projectModules.project}")
-  val ModuleInVersion(version, modules) = projectModules.mvs.head
+  val ModuleInVersion(version, modules) =  projectModules.mvs
+    .find(v => findTag(repoName, v.version).isRight)
+    .getOrElse(projectModules.mvs.head)
   val mvs = modules.map(m => ModuleVersion(m, version, projectModules.project))
   val targets = mvs.map(cached(asTarget(scalaBinaryVersion)))
   LoadedProject(projectModules.project, version, targets)

--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -7,5 +7,5 @@ typelevel:algebra.*:2.2.*
 # Gradle project with 1 Scala sub-module
 line:armeria:.*
 
-# Published from PR branch
-sbt:sbt:2.0.0-alpha.* 
+# Build problems:
+com.softwaremill.macwire:.*

--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -7,5 +7,12 @@ typelevel:algebra.*:2.2.*
 # Gradle project with 1 Scala sub-module
 line:armeria:.*
 
+# Not an official release version
+sbt:sbt:2.0.0-alpha.* 
+
 # Build problems:
+# Checking Scala 3 using constant version string
+com.github.ghostdogpr:caliban.*
 com.softwaremill.macwire:.*
+com.softwaremill.quicklens:.*
+com.47deg:fetch.*

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -86,7 +86,7 @@ zio_zio-quill {
 
 dotty-staging_zio {
   projects.exclude=[
-    // Introduced in version 2.x, we use outdated dotty_staging version
+    // Introduced in zio 2.x, we use outdated dotty_staging version
     "zio-internal-macros",
     "zio-managed"
   ]

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -1,3 +1,14 @@
+akka_akka {
+  // Based on Scala3 managed community build
+  tests = compile-only
+  sbt.commands = [
+    "set every targetSystemJdk := true",
+    "set actor/Compile/scalacOptions -= \"-Xfatal-warnings\"",
+    "set testkit/Compile/scalacOptions -= \"-Xfatal-warnings\"",
+    "set actorTests/Compile/scalacOptions -= \"-Xfatal-warnings\"",
+  ]
+}
+
 fomkin_korolev {
   projects.exclude=[
     "org.fomkin%korolev-http4s" # Conflicting cross Scala versions _3 vs _2.13
@@ -8,9 +19,24 @@ kamon-io_kamon {
   java.version=8
 }
 
+reactivemongo_reactivemongo {
+  projects.overrides = {
+    reactivemongo {
+      // Actual tests needs env set up
+      tests = compile-only
+    }
+  }
+}
+
+scala-native_scala-native.tests = compile-only  
+scalikejdbc_scalikejdbc.tests = compile-only
+
 scalaz_scalaz {
   sbt.options=["-J-Xmx5g"]
 }
+
+// Uses missing AWS credentials in tests
+seratch_awscala.tests = compile-only 
 
 softwaremill_sttp {
   sbt.options=["-J-Xmx5g"]
@@ -54,12 +80,15 @@ wvlet_airframe {
   ]
 }
 
-zio_quill {
+zio_zio-quill {
   sbt.options=["-Dquill.scala.version=<SCALA_VERSION>"]
 }
 
-zio_zio {
+dotty-staging_zio {
   projects.exclude=[
-    "dev.zio%zio-internal-macros" // Introduced in version 2.x, we use outdated dotty_staging version
+    // Introduced in version 2.x, we use outdated dotty_staging version
+    "zio-internal-macros",
+    "zio-managed"
   ]
 }
+

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -53,3 +53,13 @@ wvlet_airframe {
     "org.wvlet.airframe%airspec" # Inner sbt project, no mechanism to handle that currently
   ]
 }
+
+zio_quill {
+  sbt.options=["-Dquill.scala.version=<SCALA_VERSION>"]
+}
+
+zio_zio {
+  projects.exclude=[
+    "dev.zio%zio-internal-macros" // Introduced in version 2.x, we use outdated dotty_staging version
+  ]
+}

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -2,5 +2,7 @@ circe/circe circe/circe main
 milessabin/shapeless typelevel/shapeless-3
 playframework/play-json dotty-staging/play-json
 playframework/playframework dotty-staging/play-json
+scodec/scodec dotty-staging/scodec
+scalatest/scalatest dotty-staging/scalatest
 spray/spray spray/spray-json v1.3.6-3.1.0
 zio/zio dotty-staging/zio

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -1,6 +1,6 @@
+circe/circe circe/circe main
 milessabin/shapeless typelevel/shapeless-3
 playframework/play-json dotty-staging/play-json
 playframework/playframework dotty-staging/play-json
 spray/spray spray/spray-json v1.3.6-3.1.0
-circe/circe circe/circe main
-
+zio/zio dotty-staging/zio

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -170,7 +170,7 @@ pipeline {
                 failure {
                   script {
                     echo "Build failed, reproduce it locally using following command:"
-                    echo "scala-cli run https://raw.githubusercontent.com/VirtusLab/community-build3/master/cli/scb-cli.scala -- reproduce --jobId=${env.BUILD_NUMBER}"
+                    echo "scala-cli run https://raw.githubusercontent.com/VirtusLab/community-build3/master/cli/scb-cli.scala -- reproduce ${env.BUILD_NUMBER}"
                   }
                 }
             }

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -98,7 +98,7 @@ pipeline {
             stages {
                 stage("Build project") {
                     options {
-                      timeout(time: 1, unit: "HOURS")
+                      timeout(time: 2, unit: "HOURS")
                     } 
                     steps {
                         catchError(stageResult: 'FAILURE', catchInterruptions: false) {

--- a/project-builder/mill/build.sh
+++ b/project-builder/mill/build.sh
@@ -29,7 +29,7 @@ millSettings=(
   -D communitybuild.version="$version"
   -D communitybuild.maven.url="$mavenRepoUrl"
   -D communitybuild.scala="$scalaVersion"
-  $(echo $projectConfig | jq -r '.mill?.options? // [] | join(" ")')
+  $(echo $projectConfig | jq -r '.mill?.options? // [] | join(" ")' | sed "s/<SCALA_VERSION>/${scalaVersion}/g")
 )
 
 mill ${millSettings[@]} runCommunityBuild "$scalaVersion" "${projectConfig}" "${targets[@]}"

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -35,7 +35,7 @@ sbtSettings=(
   --batch
   --no-colors
   -Dcommunitybuild.version="$version"
-  $(echo $projectConfig | jq -r '.sbt.options? // [] | join(" ")')
+  $(echo $projectConfig | jq -r '.sbt.options? // [] | join(" ")' | sed "s/<SCALA_VERSION>/${scalaVersion}/g")
 )
 customCommands=$(echo "$projectConfig" | jq -r '.sbt?.commands // [] | join ("; ")')
 targetsString="${targets[@]}"


### PR DESCRIPTION
This PR improves the selection of projects that should be used to perform a build, by the exclusion of versions that don't have a tag in a git repo. This should allow remaining only final and RC/M releases. 

* Updated projects/filters config
* Allowed to specify <SCALA_VERISON> constant in sbt options, which would be replaced with actual value while preparing the project.