### PR TITLE
Detect Java version to use based on github workflows

### DIFF
--- a/coordinator/.scalafmt.conf
+++ b/coordinator/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = "3.4.0"
+runner.dialect = scala3
+maxColumn = 100

--- a/coordinator/build.sbt
+++ b/coordinator/build.sbt
@@ -15,6 +15,7 @@ lazy val root = project
       "net.sourceforge.htmlunit" % "htmlunit" % "2.29",
       "org.json4s" %% "json4s-native" % "4.0.4",
       "org.json4s" %% "json4s-ext" % "4.0.4",
-      "com.github.pureconfig" %% "pureconfig-core" % "0.17.1"
+      "com.github.pureconfig" %% "pureconfig-core" % "0.17.1",
+      "com.lihaoyi" %% "os-lib" % "0.8.0"
     )
   )

--- a/coordinator/src/main/scala/buildPlan.scala
+++ b/coordinator/src/main/scala/buildPlan.scala
@@ -285,7 +285,7 @@ def makeDependenciesBasedBuildPlan(
         val SetupScalaJavaVersion = raw"\s*$JavaVersion$OptQuote(.*)@(.*)$OptQuote".r
         // We can only supported this versions
         val allowedVersions = Seq("8", "11", "17")
-        val selected = os.walk
+        os.walk
           .stream(githubDir)
           .filter(os.isFile)
           .flatMap { path =>
@@ -306,8 +306,6 @@ def makeDependenciesBasedBuildPlan(
           }
           .toList
           .maxByOption(_.toInt)
-        println(selected)
-        selected
 
     readProjectConfig()
       .orElse(internalProjectConfigs(name))

--- a/coordinator/src/main/scala/deps.scala
+++ b/coordinator/src/main/scala/deps.scala
@@ -33,15 +33,8 @@ private def loadScaladexVersionsMatrix(project: Project) =
   import com.gargoylesoftware.htmlunit
   import htmlunit.*
   import htmlunit.html.HtmlPage
-  import htmlunit.javascript.JavaScriptErrorListener
   import project.{org, name}
-
-  object NoopJsErrorListener extends JavaScriptErrorListener {
-    override def loadScriptError(page: HtmlPage, url: java.net.URL, ex: Exception): Unit = ()
-    override def malformedScriptURL(page: HtmlPage, script: String, reason: java.net.MalformedURLException): Unit = ()
-    override def scriptException(page: HtmlPage, reason: ScriptException): Unit = ()
-    override def timeoutError(page: HtmlPage, x: Long, y: Long): Unit = ()
-  }
+  import java.util.logging.*
   
   val url = s"https://index.scala-lang.org/artifacts/$org/$name"
   val client = WebClient(BrowserVersion.CHROME)
@@ -53,7 +46,7 @@ private def loadScaladexVersionsMatrix(project: Project) =
   setOption(_.setTimeout(15 * 1000))
   // We set window size to trigger loading of all entries
   client.getCurrentWindow.setInnerHeight(Int.MaxValue)
-  client.setJavaScriptErrorListener(NoopJsErrorListener)
+  Logger.getLogger("com.gargoylesoftware").setLevel(Level.OFF); 
 
   val page = client.getPage[HtmlPage](url)
   Jsoup.parse(page.asXml)

--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -1,3 +1,5 @@
+# Projects to exclude in format <org>:<project>:<version>
+# Org and project should match Github names, instead of names used for artifacts (Maven)
 # Not a Scala Project
 didi:booster.*
 
@@ -8,11 +10,12 @@ typelevel:algebra.*:2.2.*
 line:armeria:.*
 
 # Not an official release version
-sbt:sbt:2.0.0-alpha.* 
+sbt:sbt:2.0.0-alpha.*
+com-lihaoyi:ammonite:.* 
 
 # Build problems:
 # Checking Scala 3 using constant version string
-com.github.ghostdogpr:caliban.*
-com.softwaremill.macwire:.*
-com.softwaremill.quicklens:.*
-com.47deg:fetch.*
+ghostdogpr:caliban.*
+softwaremill:macwire:.*
+softwaremill:quicklens:.*
+47degrees:fetch.*

--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -15,7 +15,8 @@ com-lihaoyi:ammonite:.*
 
 # Build problems:
 # Checking Scala 3 using constant version string
-ghostdogpr:caliban.*
+ghostdogpr:caliban:.*
 softwaremill:macwire:.*
 softwaremill:quicklens:.*
-47degrees:fetch.*
+47degrees:fetch:.*
+zio:zio-prelude:.*

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -3,9 +3,15 @@ akka_akka {
   tests = compile-only
   sbt.commands = [
     "set every targetSystemJdk := true",
-    "set actor/Compile/scalacOptions -= \"-Xfatal-warnings\"",
-    "set testkit/Compile/scalacOptions -= \"-Xfatal-warnings\"",
-    "set actorTests/Compile/scalacOptions -= \"-Xfatal-warnings\"",
+    """set actor/Compile/scalacOptions -= "-Xfatal-warnings"""",
+    """set testkit/Compile/scalacOptions -= "-Xfatal-warnings"""",
+    """set actorTests/Compile/scalacOptions -= "-Xfatal-warnings"""",
+  ]
+}
+
+atnos-org_eff {
+  sbt.commands = [
+    """set monixJVM/Test/unmanagedSources ~= (_.filterNot(_.getName == "TaskEffectSpec.scala"))"""
   ]
 }
 
@@ -13,6 +19,20 @@ fomkin_korolev {
   projects.exclude=[
     "org.fomkin%korolev-http4s" # Conflicting cross Scala versions _3 vs _2.13
   ]
+}
+
+higherkindness_droste {
+  sbt.commands = [
+    """set scalacheck.jvm/Compile/scalacOptions -= "-Xfatal-warnings""""
+  ]
+}
+
+http4s_http4s {
+  projects.overrides = {
+    tomcat-server.tests = compile-only
+    circe.tests = compile-only
+    blaze-client.tests = compile-only
+  }
 }
 
 reactivemongo_reactivemongo {
@@ -25,21 +45,36 @@ reactivemongo_reactivemongo {
 }
 
 scala-native_scala-native.tests = compile-only  
-scalikejdbc_scalikejdbc.tests = compile-only
+scalafx/scalafx.tests = compile-only
 
 scalatest_scalatest {
   sbt.commands=[
-    "set every Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat",
+    "set every Test/classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat",
     // From managged community build https://github.com/lampepfl/dotty/blob/fb7f900667ea57e78a098e4831be36e0a7da6cba/community-build/src/scala/dotty/communitybuild/projects.scala#L293
-    """set scalatestTestDotty / Test / managedSources ~= (_.filterNot(v => Seq("GeneratorSpec.scala", "FrameworkSuite.scala", "WaitersSpec.scala", "TestSortingReporterSpec.scala", "JavaFuturesSpec.scala", "ParallelTestExecutionSpec.scala", "TimeLimitsSpec.scala", "DispatchReporterSpec.scala", "TestThreadsStartingCounterSpec.scala", "SuiteSortingReporterSpec.scala", "CommonGeneratorsSpec.scala", "PropCheckerAssertingSpec.scala", "ConductorMethodsSuite.scala", "EventuallySpec.scala").contains(v.getName) )""",
-    """set scalacticTestDotty / Test / managedSources ~= (_.filterNot(_.getName == "NonEmptyArraySpec.scala"))""",
-    """set genRegularTests4 / Test / managedSources ~= (_.filterNot(v => Seq("FrameworkSuite.scala", "GeneratorSpec.scala", "CommonGeneratorsSpec.scala", "ParallelTestExecutionSpec.scala", "DispatchReporterSpec.scala", "TestThreadsStartingCounterSpec.scala", "EventuallySpec.scala").contains(v.getName) ))"""
+    """set scalatestTestDotty/Test/managedSources ~= (_.filterNot(v => Seq("GeneratorSpec.scala", "FrameworkSuite.scala", "WaitersSpec.scala", "TestSortingReporterSpec.scala", "JavaFuturesSpec.scala", "ParallelTestExecutionSpec.scala", "TimeLimitsSpec.scala", "DispatchReporterSpec.scala", "TestThreadsStartingCounterSpec.scala", "SuiteSortingReporterSpec.scala", "CommonGeneratorsSpec.scala", "PropCheckerAssertingSpec.scala", "ConductorMethodsSuite.scala", "EventuallySpec.scala").contains(v.getName) ))""",
+    """set scalacticTestDotty/Test/managedSources ~= (_.filterNot(_.getName == "NonEmptyArraySpec.scala"))""",
+    """set genRegularTests4/Test/managedSources ~= (_.filterNot(v => Seq("FrameworkSuite.scala", "GeneratorSpec.scala", "CommonGeneratorsSpec.scala", "ParallelTestExecutionSpec.scala", "DispatchReporterSpec.scala", "TestThreadsStartingCounterSpec.scala", "EventuallySpec.scala").contains(v.getName) ))"""
   ]
 }
 
-scalaz_scalaz {
-  sbt.options=["-J-Xmx5g"]
+scalanlp_breeze {
+  sbt.commands=[
+    // flaky tests
+    """set math/Test/unmanagedSources/excludeFilter := HiddenFileFilter || "OptimizationSpaceTest.scala" || "LinearAlgebraTest.scala" || "DenseMatrixTest.scala" || "CSCMatrixTest.scala" || "LUTest.scala" || "ProjectedQuasiNewtonTest.scala""""
+  ]
 }
+
+// is Upstream compiled with Java 11
+scalapb_scalapb.java.version = 11
+
+scalapy_scalapy.tests = compile-only
+
+scalaz_scalaz {
+  sbt.options = ["-J-Xmx8g"]
+  java.version = 8
+}
+scalikejdbc_scalikejdbc.tests = compile-only
+scalikejdbc_scalikejdbc-async.tests = compile-only
 
 // Uses missing AWS credentials in tests
 seratch_awscala.tests = compile-only 
@@ -49,7 +84,7 @@ softwaremill_sttp {
 }
 
 softwaremill_tapir {
-  sbt.options=["-J-Xmx5g"]
+  sbt.options=["-J-Xmx5g", "-J-Xss2M"]
 }
 
 reactivemongo_reactivemongo {
@@ -57,6 +92,8 @@ reactivemongo_reactivemongo {
     "reactivemongo%reactivemongo-alias" # Not a part of the main repo, defined in reactivemongo-shaded
   ]
 }
+
+testcontainers_testcontainers-scala.tests = compile-only
 
 typelevel_jawn {
   projects.exclude=[

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -27,6 +27,16 @@ reactivemongo_reactivemongo {
 scala-native_scala-native.tests = compile-only  
 scalikejdbc_scalikejdbc.tests = compile-only
 
+scalatest_scalatest {
+  sbt.commands=[
+    "set every Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat",
+    // From managged community build https://github.com/lampepfl/dotty/blob/fb7f900667ea57e78a098e4831be36e0a7da6cba/community-build/src/scala/dotty/communitybuild/projects.scala#L293
+    """set scalatestTestDotty / Test / managedSources ~= (_.filterNot(v => Seq("GeneratorSpec.scala", "FrameworkSuite.scala", "WaitersSpec.scala", "TestSortingReporterSpec.scala", "JavaFuturesSpec.scala", "ParallelTestExecutionSpec.scala", "TimeLimitsSpec.scala", "DispatchReporterSpec.scala", "TestThreadsStartingCounterSpec.scala", "SuiteSortingReporterSpec.scala", "CommonGeneratorsSpec.scala", "PropCheckerAssertingSpec.scala", "ConductorMethodsSuite.scala", "EventuallySpec.scala").contains(v.getName) )""",
+    """set scalacticTestDotty / Test / managedSources ~= (_.filterNot(_.getName == "NonEmptyArraySpec.scala"))""",
+    """set genRegularTests4 / Test / managedSources ~= (_.filterNot(v => Seq("FrameworkSuite.scala", "GeneratorSpec.scala", "CommonGeneratorsSpec.scala", "ParallelTestExecutionSpec.scala", "DispatchReporterSpec.scala", "TestThreadsStartingCounterSpec.scala", "EventuallySpec.scala").contains(v.getName) ))"""
+  ]
+}
+
 scalaz_scalaz {
   sbt.options=["-J-Xmx5g"]
 }

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -15,10 +15,6 @@ fomkin_korolev {
   ]
 }
 
-kamon-io_kamon {
-  java.version=8
-}
-
 reactivemongo_reactivemongo {
   projects.overrides = {
     reactivemongo {
@@ -50,10 +46,6 @@ reactivemongo_reactivemongo {
   projects.exclude=[
     "reactivemongo%reactivemongo-alias" # Not a part of the main repo, defined in reactivemongo-shaded
   ]
-}
-
-typelevel_fs2 {
-  java.version=17
 }
 
 typelevel_jawn {

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -2,6 +2,7 @@ circe/circe circe/circe main
 milessabin/shapeless typelevel/shapeless-3
 playframework/play-json dotty-staging/play-json
 playframework/playframework dotty-staging/play-json
-scodec/scodec dotty-staging/scodec
+scodec/scodec dotty-staging/scodec main
 spray/spray spray/spray-json v1.3.6-3.1.0
-zio/zio dotty-staging/zio
+zio/zio dotty-staging/zio resync-20220131
+scalanlp/breeze scalanlp/breeze releases/v2.0.1-RC2

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -3,6 +3,5 @@ milessabin/shapeless typelevel/shapeless-3
 playframework/play-json dotty-staging/play-json
 playframework/playframework dotty-staging/play-json
 scodec/scodec dotty-staging/scodec
-scalatest/scalatest dotty-staging/scalatest
 spray/spray spray/spray-json v1.3.6-3.1.0
 zio/zio dotty-staging/zio


### PR DESCRIPTION
This PR resolves #10 by selecting the latest version of Java used in the CI of tested projects, based on the configuration of the 2 most popular github actions used to setup CI in Scala projects: olafurpg/setup-scala and actions/setup-java