### PR TITLE
Sort versions fetched from Scaladex matrix

### DIFF
--- a/coordinator/src/main/scala/deps.scala
+++ b/coordinator/src/main/scala/deps.scala
@@ -74,7 +74,13 @@ def loadScaladexProject(scalaBinaryVersion: String)(project: Project): ProjectMo
         yield name
       ModuleInVersion(version, modules.toSeq)
 
-  ProjectModules(project, mvs.filter(_.modules.nonEmpty))
+  // Make sure that versions are ordered, some libraries don't have correct order in scaladex matrix
+  // Eg. scalanlp/breeze lists versions: 2.0, 2.0-RC1, 2.0.1-RC2, 2.0.1-RC1
+  // We want to have latests versions in front of collection
+  val modules = mvs
+    .filter(_.modules.nonEmpty)
+    .sortBy(_.version)(using Ordering[String].reverse) 
+  ProjectModules(project, modules)
 
 case class ModuleVersion(name: String, version: String, p: Project)
 


### PR DESCRIPTION
Scaladex versions matrix does not always list entries in the correct order, e.g scalanlp/breeze which does not follow semantic versioning lists version 2.0 as the latest one, even though there are available 2.0.1-RCx versions. This should fix picking incorrect version of project to build upon