### PR TITLE
Fix passing configs and parsing versions

### DIFF
--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -303,13 +303,14 @@ object BuildInfo:
       scala.reflect.ManifestFactory.classType(classOf[String])
 
     def prepareBuildPlan(): JValue =
+      val configsDir = communityBuildDir / "env" / "prod" / "config"
       val args = Seq(
         /* scalaBinaryVersion = */ 3,
         /* minStartsCount = */ 0,
         /* maxProjectsCount = */ 0,
         /* requiredProjects = */ config.customRun.projectName,
         /* replacedProjectsPath = */ "",
-        /* projectsConfigPath = */ "",
+        /* projectsConfigPath = */ configsDir / "projects-config.conf",
         /* projectsFiterPath = */ ""
       ).map("\"" + _.toString + "\"").mkString(" ")
       val coordinatorDir = communityBuildDir / "coordinator"

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -318,10 +318,16 @@ object BuildInfo:
       val buildPlanJson = os.read(coordinatorDir / "data" / "buildPlan.json")
       parse(buildPlanJson)
 
+    val JArray(projectPlans) = prepareBuildPlan()
     val projects = for
-      JArray(projectPlans) <- prepareBuildPlan()
       project <- projectPlans.take(1) // There should be only 1 project
-      plan = project.extract[ProjectBuildPlan]
+      // Config is an object, though be default would be decoded to None when we expect Option[String]
+      // We don't care about its content so we treat it as opaque string value
+      configString = project \ "config" match {
+        case JNothing | JNull => None
+        case value => Option(compact(render(value)))
+      }
+      plan = project.extract[ProjectBuildPlan].copy(config = configString)
       jdkVersion = plan.config.map(parse(_) \ "java" \ "version").flatMap(_.extractOpt[String])
     yield ProjectInfo(
       id = jobId,

--- a/coordinator/src/main/scala/core.scala
+++ b/coordinator/src/main/scala/core.scala
@@ -82,11 +82,17 @@ object ProjectBuildConfig {
 case class SemVersion(major: Int, minor: Int, patch: Int, milestone: Option[String])
 given Conversion[String, SemVersion] = _ match {
   // format: off
-  case s"$major.$minor.$patch-$milestone" => SemVersion(major.toInt, minor.toInt, patch.toInt, Some(milestone))
-  case s"$major.$minor.$patch"            => SemVersion(major.toInt, minor.toInt, patch.toInt, None)
-  case s"$major.$minor"                   => SemVersion(major.toInt, minor.toInt, 0, None)
-  case s"$major"                          => SemVersion(major.toInt, 0, 0, None)
-  // format: on
+    case s"$major.$minor.$patch-$milestone" => SemVersion(major.toInt, minor.toInt, patch.toInt, Some(milestone))
+    case s"$major.$minor.$patch"            => SemVersion(major.toInt, minor.toInt, patch.toInt, None)
+    case s"$major.$minor-$milestone"        => SemVersion(major.toInt, minor.toInt, 0, Some(milestone))
+    case s"$major.$minor"                   => SemVersion(major.toInt, minor.toInt, 0, None)
+    case s"$major-$milestone"               => SemVersion(major.toInt, 0, 0, Some(milestone))
+    // format: on
+  case version =>
+    version.toIntOption match {
+      case Some(v) => SemVersion(v, 0, 0, None)
+      case _       => SemVersion(0, 0, 0, Some(version))
+    }
 }
 
 given Ordering[SemVersion] = (x: SemVersion, y: SemVersion) => {

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -137,7 +137,7 @@ zio_zio-quill {
   sbt.options=["-Dquill.scala.version=<SCALA_VERSION>"]
 }
 
-dotty-staging_zio {
+zio_zio {
   projects.exclude=[
     // Introduced in zio 2.x, we use outdated dotty_staging version
     "zio-internal-macros",

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -1,3 +1,5 @@
+# Content of this file is expected to be moved into actual projects in the future
+
 akka_akka {
   // Based on Scala3 managed community build
   tests = compile-only
@@ -89,6 +91,10 @@ softwaremill_sttp {
 
 softwaremill_tapir {
   sbt.options=["-J-Xmx5g", "-J-Xss2M"]
+  projects.overrides {
+    // Deadlocks when executing in minikube
+    tapir-vertx-server.tests = compile-only
+  }
 }
 
 reactivemongo_reactivemongo {

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -28,11 +28,11 @@ higherkindness_droste {
 }
 
 http4s_http4s {
-  projects.overrides = {
-    tomcat-server.tests = compile-only
-    circe.tests = compile-only
-    blaze-client.tests = compile-only
-  }
+  sbt.commands = [
+    """set blazeClient/ Test/unmanagedSources/excludeFilter := HiddenFileFilter || "BlazeClientSuite.scala" || "BlazeHttp1ClientSuite.scala" || "ClientTimeoutSuite.scala""""
+    """set blazeServer/ Test/unmanagedSources/excludeFilter := HiddenFileFilter || "Http1ServerStageSpec.scala""""
+    """set tomcatServer/Test/unmanagedSources/excludeFilter := HiddenFileFilter || "TomcatServerSuite.scala""""
+  ]
 }
 
 reactivemongo_reactivemongo {
@@ -45,7 +45,7 @@ reactivemongo_reactivemongo {
 }
 
 scala-native_scala-native.tests = compile-only  
-scalafx/scalafx.tests = compile-only
+scalafx_scalafx.tests = compile-only
 
 scalatest_scalatest {
   sbt.commands=[
@@ -71,8 +71,11 @@ scalapb_scalapb.java.version = 11
 scalapy_scalapy.tests = compile-only
 
 scalaz_scalaz {
-  sbt.options = ["-J-Xmx8g"]
-  java.version = 8
+  sbt {
+    options = ["-J-Xmx5g"]
+    commands = ["set every unidoc/unidocAllSources := Nil"] // in Scala 3.1.0+ gets into infinite loop when run in containers
+  }
+
 }
 scalikejdbc_scalikejdbc.tests = compile-only
 scalikejdbc_scalikejdbc-async.tests = compile-only
@@ -95,6 +98,16 @@ reactivemongo_reactivemongo {
 }
 
 testcontainers_testcontainers-scala.tests = compile-only
+
+tpolecat_doobie {
+  sbt.commands = [
+    // as per https://github.com/scala/community-builds/pull/835#issuecomment-455729365,
+    // these subprojects require a Postgres instance for the tests to run
+    "set postgres        /Test/ executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"
+    "set `postgres-circe`/Test/ executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"
+    "set hikari          /Test/ executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"
+  ]
+}
 
 typelevel_jawn {
   projects.exclude=[

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -7,4 +7,7 @@ spray/spray spray/spray-json v1.3.6-3.1.0
 zio/zio dotty-staging/zio resync-20220131
 etorreborre/specs2 etorreborre/specs2 main
 scalanlp/breeze scalanlp/breeze releases/v2.0.1-RC2
+
+# https://github.com/lampepfl/dotty/issues/14804
 tpolecat/doobie WojciechMazur/doobie fix/3.1.1-compat
+softwaremill/tapir WojciechMazur/tapir fix/3.1.2-compat

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -6,7 +6,6 @@ scodec/scodec dotty-staging/scodec main
 spray/spray spray/spray-json v1.3.6-3.1.0
 zio/zio dotty-staging/zio resync-20220131
 etorreborre/specs2 etorreborre/specs2 main
-scalanlp/breeze scalanlp/breeze releases/v2.0.1-RC2
 
 # https://github.com/lampepfl/dotty/issues/14804
 tpolecat/doobie WojciechMazur/doobie fix/3.1.1-compat

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -7,3 +7,4 @@ spray/spray spray/spray-json v1.3.6-3.1.0
 zio/zio dotty-staging/zio resync-20220131
 etorreborre/specs2 etorreborre/specs2 main
 scalanlp/breeze scalanlp/breeze releases/v2.0.1-RC2
+tpolecat/doobie WojciechMazur/doobie fix/3.1.1-compat

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -44,7 +44,7 @@ logFile=build.log
 
 function runSbt() {
   # Use `setPublishVersion` instead of `every version`, as it might overrte Jmh/Jcstress versions
-  forceScalaVersion=$1projectConfig
+  forceScalaVersion=$1
   setScalaVersionCmd="++$scalaVersion"
   if [[ "$forceScalaVersion" == "forceScala" ]]; then
     setScalaVersionCmd="++$scalaVersion!"

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -34,6 +34,7 @@ fi
 sbtSettings=(
   --batch
   --no-colors
+  --verbose
   -Dcommunitybuild.version="$version"
   $(echo $projectConfig | jq -r '.sbt.options? // [] | join(" ")' | sed "s/<SCALA_VERSION>/${scalaVersion}/g")
 )
@@ -43,7 +44,7 @@ logFile=build.log
 
 function runSbt() {
   # Use `setPublishVersion` instead of `every version`, as it might overrte Jmh/Jcstress versions
-  forceScalaVersion=$1
+  forceScalaVersion=$1projectConfig
   setScalaVersionCmd="++$scalaVersion"
   if [[ "$forceScalaVersion" == "forceScala" ]]; then
     setScalaVersionCmd="++$scalaVersion!"


### PR DESCRIPTION
* Fix passing configs in the cli to the reproducer implementation
* Fix parsing versions 
* Use internal (default) config whenusing cli `run` command
* Update configs
* Use alternative builds for tapir and doobie due to typer regression in 3.1.2 builds