### PR TITLE
Generate build reports after the build run

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
 version = "3.4.0"
-runner.dialect = scala213
+runner.dialect = scala3
 maxColumn = 100

--- a/README.md
+++ b/README.md
@@ -93,19 +93,19 @@ eval $(minikube -p minikube docker-env)
 Most likely you'll need to build the base image only once (it doesn't get modified too often but building it takes quite a lot of time), e.g.:
 
 ```shell
-scripts/build-builder-base.sh v0.0.5
+scripts/build-builder-base.sh v0.0.6
 ```
 
 Build all the remaining images
 
 ```shell
-scripts/build-quick.sh v0.0.5
+scripts/build-quick.sh v0.0.6
 ```
 
 or (re)build each image separately e.g.
 
 ```shell
-scripts/build-mvn-repo.sh v0.0.5
+scripts/build-mvn-repo.sh v0.0.6
 ```
 
 ### Deploying and debugging in k8s

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -741,7 +741,10 @@ class MinikubeReproducer(using config: Config, build: BuildInfo):
         check = check,
         stdout = os.Inherit,
         stderr = if check then os.Inherit else os.Pipe,
-        env = Map("CB_K8S_NAMESPACE" -> k8s.namespace)
+        env = Map(
+          "CB_K8S_NAMESPACE" -> k8s.namespace,
+          "CB_VERSION" -> communityBuildVersion
+        )
       )
 
 object MinikubeReproducer:
@@ -772,6 +775,7 @@ object MinikubeReproducer:
         "--timeout=1m"
       )
       .call(check = false, stderr = os.Pipe)
+    println("Waiting for Maven repository to start...")
     while {
       val p = waitForPod()
       p.exitCode != 0 && p.err.text().contains("error: no matching resources")

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -26,7 +26,7 @@ given ExecutionContext = ExecutionContext.Implicits.global
 
 class FailedProjectException(msg: String) extends RuntimeException(msg) with NoStackTrace
 
-val communityBuildVersion = sys.props.getOrElse("communitybuild.version", "v0.0.5")
+val communityBuildVersion = sys.props.getOrElse("communitybuild.version", "v0.0.6")
 private val CBRepoName = "VirtusLab/community-build3"
 val projectBuilderUrl = s"https://raw.githubusercontent.com/$CBRepoName/master/project-builder"
 lazy val communityBuildDir = sys.props

--- a/coordinator/src/main/scala/deps.scala
+++ b/coordinator/src/main/scala/deps.scala
@@ -18,7 +18,7 @@ def loadProjects(scalaRelease: String): Seq[Project] =
       }
     }
   LazyList
-    .from(0)
+    .from(1) // page 0 and page 1 have the same content
     .map(load)
     .takeWhile(_.nonEmpty)
     .flatten

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -63,7 +63,7 @@ scalatest_scalatest {
 scalanlp_breeze {
   sbt.commands=[
     // flaky tests
-    """set math/Test/unmanagedSources/excludeFilter := HiddenFileFilter || "OptimizationSpaceTest.scala" || "LinearAlgebraTest.scala" || "DenseMatrixTest.scala" || "CSCMatrixTest.scala" || "LUTest.scala" || "ProjectedQuasiNewtonTest.scala""""
+    """set math/Test/unmanagedSources/excludeFilter := HiddenFileFilter || "OptimizationSpaceTest.scala" || "LinearAlgebraTest.scala" || "DenseMatrixTest.scala" || "CSCMatrixTest.scala" || "LUTest.scala" || "ProjectedQuasiNewtonTest.scala" || "InvGammaTest.scala" """
   ]
 }
 

--- a/jenkins/scripts/buildReport.scala
+++ b/jenkins/scripts/buildReport.scala
@@ -1,0 +1,253 @@
+//> using scala "3.1.1"
+//> using lib "com.sksamuel.elastic4s:elastic4s-client-esjava_2.13:7.17.2"
+//> using lib "com.lihaoyi::os-lib:0.8.1"
+//> using lib "org.slf4j:slf4j-simple:1.6.4"
+
+import com.sksamuel.elastic4s
+import elastic4s.*
+import elastic4s.http.JavaClient
+import elastic4s.ElasticDsl.*
+import elastic4s.requests.searches.aggs.TermsOrder
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
+import org.apache.http.impl.nio.client.*
+import org.apache.http.impl.client.BasicCredentialsProvider
+import org.apache.http.auth.*
+
+import scala.language.implicitConversions
+import scala.concurrent.*
+import scala.concurrent.duration.*
+
+given ExecutionContext = ExecutionContext.global
+
+@main def reportBuildSummary(
+    elasticsearchUrl: String,
+    buildId: String,
+    output: String // Path to output file or empty if stdout
+) =
+  val outputFile = Option.when(output.nonEmpty)(os.pwd / output)
+  val clientConfig = new HttpClientConfigCallback {
+    override def customizeHttpClient(
+        httpClientBuilder: HttpAsyncClientBuilder
+    ): HttpAsyncClientBuilder = {
+      val creds = new BasicCredentialsProvider()
+      creds.setCredentials(
+        AuthScope.ANY,
+        new UsernamePasswordCredentials(
+          sys.env("ELASTIC_USERNAME"),
+          sys.env("ELASTIC_PASSWORD")
+        )
+      )
+      httpClientBuilder
+        .setDefaultCredentialsProvider(creds)
+        // Custom SSL context that would not require ES certificate
+        .setSSLContext(unsafe.UnsafeSSLContext)
+    }
+  }
+
+  val client = ElasticClient(
+    JavaClient(
+      ElasticProperties(elasticsearchUrl),
+      clientConfig
+    )
+  )
+
+  val AllBuilds = "allBuild"
+  val BuildsById = "buildById"
+  val ProjectBuildSummarriesIdx = "project-build-summary"
+
+  def getBuildReport(): Future[BuildReport] = for {
+    response <- client.execute(
+      search(ProjectBuildSummarriesIdx)
+        .query(termQuery("buildId", buildId))
+        // Default limit equals 10k results. Should be more then ever needed
+        .limit(10 * 1000)
+        .sourceExclude("logs")
+        .aggregations(
+          globalAggregation(AllBuilds)
+            .subAggregations(
+              termsAgg(BuildsById, "buildId")
+                .order(TermsOrder("_key", asc = false))
+                .size(10)
+            )
+        )
+    )
+    result = response.result
+  } yield BuildReport(
+    buildId = buildId,
+    buildIds = result.aggregations
+      .global(AllBuilds)
+      .terms(BuildsById)
+      .buckets
+      .map(_.key),
+    projects = result.to[ProjectSummary]
+  )
+
+  val task = for {
+    queryResult <- getBuildReport()
+    report = showBuildReport(queryResult)
+  } yield outputFile match {
+    case None       => println(report)
+    case Some(file) => os.write.over(target = file, data = report)
+  }
+  // Needed for applicaiton to exit
+  task.onComplete { result =>
+    result.failed.foreach(err => sys.error(err.toString))
+    client.close()
+  }
+  Await.result(task, 5.minute)
+end reportBuildSummary
+
+def showBuildReport(report: BuildReport): String =
+  val BuildReport(buildId, buildIds, projects) = report
+  val Ident = "  "
+  val Ident2 = Ident * 2
+  val Ident3 = Ident * 3
+
+  def showSuccessfullProject(project: ProjectSummary) =
+    val ProjectSummary(name, version, _, _, modules) = project
+    s"""$Ident+ $name: Version: $version""".stripMargin
+
+  def showFailedProject(project: ProjectSummary) =
+    val ProjectSummary(name, version, _, _, modules) = project
+    s"""$Ident- $name
+       |${Ident2}Version: $version
+       |${Ident2}Successfull modules: ${project.successfullModules.size}
+       |${project.successfullModules
+      .map(m => s"$Ident2+ ${m.name}")
+      .mkString("\n")}
+       |${Ident2}Failed modules: ${project.failedModules.size}
+       |${project.failedModules.map(showFailedModule(_)).mkString("\n")}
+       |""".stripMargin
+
+  def showFailedModule(module: ModuleSummary) =
+    def showResults(res: List[String]) =
+      if res.isEmpty then "None" else res.mkString("[", ", ", "]")
+
+    s"""${Ident2}- ${module.name}
+    |${Ident3}Passed:  ${showResults(module.passed)}
+    |${Ident3}Failed:  ${showResults(module.failed)}""".stripMargin
+
+  if projects.isEmpty then
+    s"""No results found for build '$buildId'
+       |Latests known builds: ${buildIds
+      .map("\'" + _ + "\'")
+      .mkString(" ")}""".stripMargin
+  else
+    s"""Build Id:        $buildId
+    |Projects count:  ${projects.size}
+    |Scala version:   ${report.scalaVersion}
+    |Failed projects: ${report.failedProjects.size} 
+    |${report.failedProjects
+      .map(showFailedProject(_))
+      .mkString("\n\n")}
+    |Successfull projects: ${report.sucsessfullProjects.size}
+    |${report.sucsessfullProjects.map(showSuccessfullProject(_)).mkString("\n")}
+    |""".stripMargin
+
+case class BuildReport(
+    buildId: String,
+    buildIds: Seq[String],
+    projects: Seq[ProjectSummary]
+) {
+  lazy val scalaVersion: String = projects.head.scalaVersion
+  lazy val (sucsessfullProjects, failedProjects) =
+    projects.partition(_.status == BuildStatus.Success)
+}
+
+enum BuildStatus:
+  case Failure, Success
+enum ModuleBuildResult:
+  case Ok, Failed, Skipped
+
+case class ModuleSummary(
+    name: String,
+    compile: ModuleBuildResult,
+    doc: ModuleBuildResult,
+    testsCompile: ModuleBuildResult,
+    tests: ModuleBuildResult,
+    publish: ModuleBuildResult
+) {
+  def hasFailure = productIterator.contains(ModuleBuildResult.Failed)
+  private lazy val results = productElementNames
+    .zip(productIterator)
+    .collect { case (fieldName, result: ModuleBuildResult) =>
+      (fieldName, result)
+    }
+    .toList
+  private def collectResults(expected: ModuleBuildResult) =
+    results.collect { case (name, `expected`) => name }.toList
+
+  lazy val passed = collectResults(ModuleBuildResult.Ok)
+  lazy val failed = collectResults(ModuleBuildResult.Failed)
+  lazy val skipped = collectResults(ModuleBuildResult.Skipped)
+}
+case class ProjectSummary(
+    projectName: String,
+    version: String,
+    scalaVersion: String,
+    status: BuildStatus,
+    projectsSummary: List[ModuleSummary]
+) {
+  lazy val (failedModules, successfullModules) =
+    projectsSummary.partition(_.hasFailure)
+}
+
+given Conversion[String, ModuleBuildResult] = _ match {
+  case "ok"      => ModuleBuildResult.Ok
+  case "failed"  => ModuleBuildResult.Failed
+  case "skipped" => ModuleBuildResult.Skipped
+}
+
+given HitReader[ProjectSummary] = (hit: Hit) => {
+  val source = hit.sourceAsMap
+  util.Try {
+    val status = source("status") match {
+      case "failure" => BuildStatus.Failure
+      case "success" => BuildStatus.Success
+    }
+    val modulesSummary =
+      for
+        modueleSource <- source("summary")
+          .asInstanceOf[List[Map[String, String]]]
+      yield ModuleSummary(
+        name = modueleSource("module"),
+        compile = modueleSource("compile"),
+        doc = modueleSource("doc"),
+        testsCompile = modueleSource("test-compile"),
+        tests = modueleSource("test"),
+        publish = modueleSource("publish")
+      )
+    ProjectSummary(
+      projectName = source("projectName").toString.replaceFirst("_", "/"),
+      version = source("version").toString,
+      scalaVersion = source("scalaVersion").toString,
+      status = status,
+      projectsSummary = modulesSummary
+    )
+  }
+
+}
+
+object unsafe {
+  import javax.net.ssl.*
+  import java.security.cert.X509Certificate
+
+  lazy val UnsafeSSLContext = {
+    object TrustAll extends X509TrustManager {
+      override def getAcceptedIssuers(): Array[X509Certificate] = Array()
+      override def checkClientTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String
+      ) = ()
+      override def checkServerTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String
+      ) = ()
+    }
+
+    val instance = SSLContext.getInstance("SSL")
+    instance.init(null, Array(TrustAll), new java.security.SecureRandom())
+    instance
+  }
+
+}

--- a/jenkins/scripts/buildReport.scala
+++ b/jenkins/scripts/buildReport.scala
@@ -109,19 +109,23 @@ def showBuildReport(report: BuildReport): String =
 
   def showFailedProject(project: ProjectSummary) =
     val ProjectSummary(name, version, _, _, modules) = project
+    def showModules(label: String, results: Seq[ModuleSummary])(
+        show: ModuleSummary => String
+    ) = 
+      s"${Ident2}$label modules: ${results.size}" + {
+        if results.isEmpty then ""
+        else results.map(show).mkString("\n", "\n", "")
+      }
     s"""$Ident- $name
        |${Ident2}Version: $version
-       |${Ident2}Successfull modules: ${project.successfullModules.size}
-       |${project.successfullModules
-      .map(m => s"$Ident2+ ${m.name}")
-      .mkString("\n")}
-       |${Ident2}Failed modules: ${project.failedModules.size}
-       |${project.failedModules.map(showFailedModule(_)).mkString("\n")}
+       |${showModules("Successfull", project.successfullModules)(m =>
+      s"$Ident2+ ${m.name}"
+    )}
+       |${showModules("Failed", project.failedModules)(showFailedModule(_))}
        |""".stripMargin
 
   def showFailedModule(module: ModuleSummary) =
-    def showResults(res: List[String]) =
-      if res.isEmpty then "None" else res.mkString("[", ", ", "]")
+    def showResults(res: List[String]) = res.mkString("[", ", ", "]")
 
     s"""${Ident2}- ${module.name}
     |${Ident3}Passed:  ${showResults(module.passed)}
@@ -139,7 +143,7 @@ def showBuildReport(report: BuildReport): String =
     |Failed projects: ${report.failedProjects.size} 
     |${report.failedProjects
       .map(showFailedProject(_))
-      .mkString("\n\n")}
+      .mkString("\n")}
     |Successfull projects: ${report.sucsessfullProjects.size}
     |${report.sucsessfullProjects.map(showSuccessfullProject(_)).mkString("\n")}
     |""".stripMargin

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -145,7 +145,7 @@ pipeline {
                                         def timestamp = java.time.LocalDateTime.now()
                                         def buildStatus = getBuildStatus()
                                         0 == sh (
-                                          script: "/build/feed-elastic.sh '${params.elasticSearchUrl}' '${params.projectName}' '${buildStatus}' '${timestamp}' build-summary.txt build-logs.txt",
+                                          script: "/build/feed-elastic.sh '${params.elasticSearchUrl}' '${params.projectName}' '${buildStatus}' '${timestamp}' build-summary.txt build-logs.txt '${params.version}' '${params.scalaVersion}' '${params.buildName}'",
                                           returnStatus: true
                                         )
                                     } else true

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -64,7 +64,7 @@ pipeline {
                               name: mvn-repo-cert
                           containers:
                           - name: project-builder
-                            image: virtuslab/scala-community-build-project-builder:jdk${params.javaVersion?: 11}-v0.0.5
+                            image: virtuslab/scala-community-build-project-builder:jdk${params.javaVersion?: 11}-v0.0.6
                             imagePullPolicy: IfNotPresent
                             volumeMounts:
                             - name: mvn-repo-cert

--- a/jenkins/seeds/buildCompiler.groovy
+++ b/jenkins/seeds/buildCompiler.groovy
@@ -33,7 +33,7 @@ pipeline {
                               name: mvn-repo-cert
                           containers:
                           - name: compiler-builder
-                            image: virtuslab/scala-community-build-compiler-builder:v0.0.5
+                            image: virtuslab/scala-community-build-compiler-builder:v0.0.6
                             imagePullPolicy: IfNotPresent
                             volumeMounts:
                             - name: mvn-repo-cert

--- a/jenkins/seeds/computeBuildPlan.groovy
+++ b/jenkins/seeds/computeBuildPlan.groovy
@@ -24,7 +24,7 @@ pipeline {
                         spec:
                           containers:
                           - name: coordinator
-                            image: virtuslab/scala-community-build-coordinator:v0.0.5
+                            image: virtuslab/scala-community-build-coordinator:v0.0.6
                             imagePullPolicy: IfNotPresent
                             command:
                             - cat

--- a/k8s/jenkins.yaml
+++ b/k8s/jenkins.yaml
@@ -51,6 +51,8 @@ jenkins:
         mountPath: /var/jenkins_home/common-lib/vars
       - name: build-configs
         mountPath: /var/jenkins_home/build-configs
+      - name: build-scripts
+        mountPath: /var/jenkins_home/build-scripts
     volumes:
     - name: seed-jobs
       configMap:
@@ -63,6 +65,10 @@ jenkins:
     - name: build-configs
       configMap:
         name: jenkins-build-configs
+        defaultMode: 420
+    - name: build-scripts
+      configMap:
+        name: jenkins-build-scripts
         defaultMode: 420
     restartPolicy: ""
     imagePullSecrets: []

--- a/k8s/mvn-repo.yaml
+++ b/k8s/mvn-repo.yaml
@@ -20,7 +20,7 @@ spec:
           secretName: mvn-repo-keystore
       containers:
       - name: mvn-repo
-        image: virtuslab/scala-community-build-mvn-repo:v0.0.5
+        image: virtuslab/scala-community-build-mvn-repo:v0.0.6
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/kibana/mappings/projectBuildSummary.json
+++ b/kibana/mappings/projectBuildSummary.json
@@ -1,0 +1,63 @@
+{
+  "mappings": {
+    "dynamic": false,
+    "properties": {
+      "projectName": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "buildId": {
+        "type": "keyword"
+      },
+      "timestamp": {
+        "type": "date"
+      },
+      "version": {
+        "type": "version"
+      },
+      "scalaVersion": {
+        "type": "version"
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "summary": {
+        "type": "nested", 
+        "properties": {
+          "module": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "compile": {
+            "type": "keyword"
+          },
+          "doc": {
+            "type": "keyword"
+          },
+          "publish": {
+            "type": "keyword"
+          },
+          "test": {
+            "type": "keyword"
+          },
+          "test-compile": {
+            "type": "keyword"
+          }
+        }
+      },
+      "logs": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/project-builder/feed-elastic.sh
+++ b/project-builder/feed-elastic.sh
@@ -33,7 +33,7 @@ jsonFile=$(mktemp /tmp/feed-elastic-tmp.XXXXXX)
 
 echo "$json" > "$jsonFile"
           
-response=$(curl -v -i -k -w "\n%{http_code}" --user "$ELASTIC_USERNAME:$ELASTIC_PASSWORD" -H "Content-Type: application/json" "${elasticUrl}/community-build/doc" -d "@${jsonFile}")
+response=$(curl -v -i -k -w "\n%{http_code}" --user "$ELASTIC_USERNAME:$ELASTIC_PASSWORD" -H "Content-Type: application/json" "${elasticUrl}/project-build-summary/_doc" -d "@${jsonFile}")
 responseStatus=$(tail -n1 <<< "$response")
 
 rm "$jsonFile"

--- a/project-builder/feed-elastic.sh
+++ b/project-builder/feed-elastic.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-if [ $# -ne 6 ]; then
-  echo "Wrong number of script arguments"
+if [ $# -ne 9 ]; then
+  echo "Wrong number of script arguments, got $#, expected 7"
   exit 1
 fi
 
@@ -12,14 +12,22 @@ buildResult="$3"
 timestamp="$4"
 buildSummaryFile="$5"
 logsFile="$6"
+version="$7"
+scalaVersion="$8"
+buildId="$9"
+
+buildSummary="$(cat ${buildSummaryFile})"
 
 json=$(jq -n \
           --arg res "$buildResult" \
           --arg ts "$timestamp" \
           --arg pn "$projectName" \
-          --rawfile sum "$buildSummaryFile" \
+          --arg ver "$version" \
+          --arg scVer "$scalaVersion" \
+          --arg buildId "$buildId" \
+          --argjson sum "$buildSummary" \
           --rawfile logs "$logsFile" \
-          '{res: $res, build_timestamp: $ts, project_name: $pn, detailed_result: $sum, logs: $logs}')
+          '{projectName: $pn, version: $ver, scalaVersion: $scVer, status: $res, timestamp: $ts, buildId: $buildId, summary: $sum, logs: $logs}')
 
 jsonFile=$(mktemp /tmp/feed-elastic-tmp.XXXXXX)
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -7,7 +7,7 @@ if [ $# -ne 1 ]; then
 fi
 
 VERSION="$1"
-export PREV_CB_VERSION="v0.0.5"
+export PREV_CB_VERSION="v0.0.6"
 
 javaDefault=11
 javaAccessoryVersions=(8 17)

--- a/scripts/configure-elasticsearch.sh
+++ b/scripts/configure-elasticsearch.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+set -x 
+scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $scriptDir/utils.sh
+
+username="elastic"
+password=$(scbk get secret community-build-es-elastic-user -o go-template='{{.data.elastic | base64decode}}')
+
+scbk exec community-build-es-default-0 -- \
+  curl -k --user ${username}:${password} \
+  -X PUT "https://localhost:9200/project-build-summary?pretty" \
+  -H 'Content-Type: application/json'  -d "$(cat ${scriptDir}/../kibana/mappings/projectBuildSummary.json)"
+

--- a/scripts/configure-elasticsearch.sh
+++ b/scripts/configure-elasticsearch.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -e
-set -x 
+
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $scriptDir/utils.sh
 
 username="elastic"
 password=$(scbk get secret community-build-es-elastic-user -o go-template='{{.data.elastic | base64decode}}')
 
+scbk wait po/community-build-es-default-0  --for=condition=Ready
 scbk exec community-build-es-default-0 -- \
   curl -k --user ${username}:${password} \
   -X PUT "https://localhost:9200/project-build-summary?pretty" \

--- a/scripts/start-elastic.sh
+++ b/scripts/start-elastic.sh
@@ -4,7 +4,10 @@ set -e
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $scriptDir/utils.sh
 
-kubectl create -f https://download.elastic.co/downloads/eck/2.0.0/crds.yaml
+kubectl create -f https://download.elastic.co/downloads/eck/2.0.0/crds.yaml || true
 kubectl apply -f https://download.elastic.co/downloads/eck/2.0.0/operator.yaml
 
 scbk apply -f k8s/elastic.yaml
+
+sleep 3
+${scriptDir}/configure-elasticsearch.sh

--- a/scripts/start-jenkins.sh
+++ b/scripts/start-jenkins.sh
@@ -30,6 +30,7 @@ scbk apply -f $scriptDir/../k8s/auth/authz-matrix.yaml
 scbk create configmap jenkins-seed-jobs --from-file=$scriptDir/../jenkins/seeds --dry-run=client -o yaml | scbk apply -f -
 scbk create configmap jenkins-common-lib-vars --from-file=$scriptDir/../jenkins/common-lib/vars --dry-run=client -o yaml | scbk apply -f -
 scbk create configmap jenkins-build-configs --from-file=$scriptDir/../env/prod/config --dry-run=client -o yaml | scbk apply -f -
+scbk create configmap jenkins-build-scripts --from-file=$scriptDir/../jenkins/scripts --dry-run=client -o yaml | scbk apply -f -
 
 jenkinsClientId=$(scbk get secret/jenkins-github-oauth-secret -o 'jsonpath={.data.clientID}' | base64 -d)
 

--- a/scripts/start-mvn-repo.sh
+++ b/scripts/start-mvn-repo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 source $scriptDir/utils.sh
 
 export MVN_REPO_KEYSTORE_PASSWORD=$(openssl rand -base64 32)
@@ -12,4 +12,10 @@ scbk create secret generic mvn-repo-keystore --from-file=$scriptDir/../secrets/m
 scbk create secret generic mvn-repo-passwords --from-literal=keystore-password="$MVN_REPO_KEYSTORE_PASSWORD"
 scbk create cm mvn-repo-cert --from-file=$scriptDir/../secrets/mvn-repo.crt
 scbk apply -f $scriptDir/../k8s/mvn-repo-data.yaml
-scbk apply -f $scriptDir/../k8s/mvn-repo.yaml
+
+mvnRepoYaml=$scriptDir/../k8s/mvn-repo.yaml
+if [[ ! -z "${CB_VERSION}" ]]; then
+  cat ${mvnRepoYaml} | sed -E "s/(image: virtuslab\/scala-community-build-mvn-repo):.*/\1:${CB_VERSION}/" - | scbk apply -f -
+else
+  scbk apply -f ${mvnRepoYaml}
+fi

--- a/scripts/stop-jenkins.sh
+++ b/scripts/stop-jenkins.sh
@@ -12,5 +12,6 @@ fi
 helm -n $CB_K8S_NAMESPACE delete jenkins
 
 scbk delete configmap jenkins-build-configs
+scbk delete configmap jenkins-build-scripts
 scbk delete configmap jenkins-common-lib-vars
 scbk delete configmap jenkins-seed-jobs

--- a/scripts/test-build.sh
+++ b/scripts/test-build.sh
@@ -7,6 +7,9 @@ testNamespace=scala3-community-build-test
 compilerBuilderTimeout=60m
 projectBuilderTimeout=5m
 
+kubectl delete namespace $testNamespace --ignore-not-found=true
+kubectl create namespace $testNamespace
+
 CB_VERSION="test" \
 CB_K8S_NAMESPACE="${testNamespace}" \
 $scriptDir/start-mvn-repo.sh

--- a/scripts/test-build.sh
+++ b/scripts/test-build.sh
@@ -7,20 +7,9 @@ testNamespace=scala3-community-build-test
 compilerBuilderTimeout=60m
 projectBuilderTimeout=5m
 
-export MVN_REPO_KEYSTORE_PASSWORD=$(openssl rand -base64 32)
-
-kubectl delete namespace $testNamespace --ignore-not-found=true
-kubectl create namespace $testNamespace
-
-$scriptDir/generate-secrets.sh
-
-kubectl -n $testNamespace create secret generic mvn-repo-keystore --from-file=$scriptDir/../secrets/mvn-repo.p12
-kubectl -n $testNamespace create secret generic mvn-repo-passwords --from-literal=keystore-password="$MVN_REPO_KEYSTORE_PASSWORD"
-kubectl -n $testNamespace create cm mvn-repo-cert --from-file=$scriptDir/../secrets/mvn-repo.crt
-kubectl -n $testNamespace apply -f $scriptDir/../k8s/mvn-repo-data.yaml
-cat $scriptDir/../k8s/mvn-repo.yaml \
-  | sed -E 's/(image: virtuslab\/scala-community-build-mvn-repo):.*/\1:test/' \
-  | kubectl -n $testNamespace apply -f -
+CB_VERSION="test" \
+CB_K8S_NAMESPACE="${testNamespace}" \
+$scriptDir/start-mvn-repo.sh
 
 function compilerBuilderFailed() {
   echo "Failed to publish scala"

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -x
 
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 cd $scriptDir/../cli


### PR DESCRIPTION
This PR adds support for creating a build report after completion of the build gathering information about failed and successful projects, based on the results fetched from Elasticsearch. 

* Renamed community-build index to project-build-summary and added explicit mapping
* Added script for setting the new mapping in Elasticsearch 
* Increased amount of data passed to the Elasticsearch report: 
   - buildId - allowing to group build 
   - scalaVersion 
   - version - version of the project being build
* Changed layout of the module results to allow for easier querying based on the nested objects
* Added a script used to generate human-readable build report
* Added post runBuild job phase generating report and saving it as an artifact
* Fix bug in duplicates the loading scaladex info
