### PR TITLE
Gather task statistics and introduced shared code between build tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: coursier/setup-action@v1
         with:
-          apps: scala sbt mill
+          apps: scala sbt mill:0.9.12
 
       - name: Install scala-cli
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: coursier/setup-action@v1
         with:
-          apps: scala sbt mill:0.9.12
+ump          apps: scala sbt mill:0.10.2
 
       - name: Install scala-cli
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: coursier/setup-action@v1
         with:
-ump          apps: scala sbt mill:0.10.2
+          apps: scala sbt mill:0.10.2
 
       - name: Install scala-cli
         run: |

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -1214,7 +1214,8 @@ class LocalReproducer(using config: Config, build: BuildInfo):
           .call(
             cwd = projectDir,
             stdout = output,
-            stderr = output
+            stderr = output,
+            env = Map("MILL_VERSION" -> "0.9.12")
           )
       }
       val scalaVersion = Seq("--scalaVersion", effectiveScalaVersion)

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -1198,7 +1198,10 @@ class LocalReproducer(using config: Config, build: BuildInfo):
           // We need to rename .scala files into .sc to allow for their usage in Mill
           val relPath = path.relativeTo(sharedSourcesDir).toNIO
           val fileSc = relPath.getFileName().toString.stripSuffix(".scala") + ".sc"
-          val outputPath = projectDir / os.RelPath(relPath.getParent) / fileSc
+          val outputPath =
+            Option(relPath.getParent)
+              .map(os.RelPath(_))
+              .foldLeft(projectDir)(_ / _) / fileSc
           os.copy(path, outputPath, replaceExisting = true)
         }
 

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -1204,6 +1204,8 @@ class LocalReproducer(using config: Config, build: BuildInfo):
               .foldLeft(projectDir)(_ / _) / fileSc
           os.copy(path, outputPath, replaceExisting = true)
         }
+      // Mill 0.10.x series is breaking
+      os.write.over(projectDir / ".mill-version", "0.9.12")
 
     override def runBuild(): Unit =
       def mill(commands: os.Shellable*) = {
@@ -1215,7 +1217,6 @@ class LocalReproducer(using config: Config, build: BuildInfo):
             cwd = projectDir,
             stdout = output,
             stderr = output,
-            env = Map("MILL_VERSION" -> "0.9.12")
           )
       }
       val scalaVersion = Seq("--scalaVersion", effectiveScalaVersion)

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -1192,7 +1192,7 @@ class LocalReproducer(using config: Config, build: BuildInfo):
       os.remove(buildFileCopy)
       os.copy.into(millBuilder / MillCommunityBuildSc, projectDir, replaceExisting = true)
       os.list(projectBuilderDir / "shared")
-        .foreach(os.copy.into(_, projectDir / "project", replaceExisting = true))
+        .foreach(os.copy.into(_, projectDir, replaceExisting = true))
 
     override def runBuild(): Unit =
       def mill(commands: os.Shellable*) = {

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -1204,8 +1204,8 @@ class LocalReproducer(using config: Config, build: BuildInfo):
               .foldLeft(projectDir)(_ / _) / fileSc
           os.copy(path, outputPath, replaceExisting = true)
         }
-      // Mill 0.10.x series is breaking
-      os.write.over(projectDir / ".mill-version", "0.9.12")
+      // Force mill version due to breaking changes between 0.9.x and 0.10.x
+      os.write.over(projectDir / ".mill-version", "0.10.2")
 
     override def runBuild(): Unit =
       def mill(commands: os.Shellable*) = {

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -21,6 +21,7 @@ import coursier.cache.*
 import scala.util.control.NoStackTrace
 
 import Config.*
+import os.PathConvertible
 given Formats = DefaultFormats
 given ExecutionContext = ExecutionContext.Implicits.global
 
@@ -1195,9 +1196,9 @@ class LocalReproducer(using config: Config, build: BuildInfo):
       os.list(sharedSourcesDir)
         .foreach { path =>
           // We need to rename .scala files into .sc to allow for their usage in Mill
-          val segments = path.relativeTo(sharedSourcesDir).segments
-          val newName = segments.last.stripSuffix(".scala") + ".sc"
-          val outputPath = projectDir / os.RelPath(segments.init, newName)
+          val relPath = path.relativeTo(sharedSourcesDir).toNIO
+          val fileSc = relPath.getFileName().toString.stripSuffix(".scala") + ".sc"
+          val outputPath = projectDir / os.RelPath(relPath.getParent) / fileSc
           os.copy(path, outputPath, replaceExisting = true)
         }
 

--- a/jenkins/scripts/buildReport.scala
+++ b/jenkins/scripts/buildReport.scala
@@ -16,8 +16,10 @@ import org.apache.http.auth.*
 import scala.language.implicitConversions
 import scala.concurrent.*
 import scala.concurrent.duration.*
+import scala.reflect.ClassTag
 
 given ExecutionContext = ExecutionContext.global
+import FromMap.given
 
 @main def reportBuildSummary(
     elasticsearchUrl: String,
@@ -159,30 +161,40 @@ case class BuildReport(
 
 enum BuildStatus:
   case Failure, Success
-enum ModuleBuildResult:
+enum StepStatus:
   case Ok, Failed, Skipped
+
+sealed trait StepResult {
+  def status: StepStatus
+}
+
+// Currently we don't use any of the other result fields
+case class CompileResult(status: StepStatus) extends StepResult
+case class DocsResult(status: StepStatus) extends StepResult
+case class TestsResult(status: StepStatus) extends StepResult
+case class PublishResult(status: StepStatus) extends StepResult
 
 case class ModuleSummary(
     name: String,
-    compile: ModuleBuildResult,
-    doc: ModuleBuildResult,
-    testsCompile: ModuleBuildResult,
-    tests: ModuleBuildResult,
-    publish: ModuleBuildResult
+    compile: CompileResult,
+    doc: DocsResult,
+    testsCompile: CompileResult,
+    tests: TestsResult,
+    publish: PublishResult
 ) {
-  def hasFailure = productIterator.contains(ModuleBuildResult.Failed)
-  private lazy val results = productElementNames
+  def hasFailure = results.exists(_._2 == StepStatus.Failed)
+  private lazy val results: List[(String, StepStatus)] = productElementNames
     .zip(productIterator)
-    .collect { case (fieldName, result: ModuleBuildResult) =>
-      (fieldName, result)
+    .collect { case (fieldName, result: StepResult) =>
+      (fieldName, result.status)
     }
     .toList
-  private def collectResults(expected: ModuleBuildResult) =
+  private def collectResults(expected: StepStatus) =
     results.collect { case (name, `expected`) => name }.toList
 
-  lazy val passed = collectResults(ModuleBuildResult.Ok)
-  lazy val failed = collectResults(ModuleBuildResult.Failed)
-  lazy val skipped = collectResults(ModuleBuildResult.Skipped)
+  lazy val passed = collectResults(StepStatus.Ok)
+  lazy val failed = collectResults(StepStatus.Failed)
+  lazy val skipped = collectResults(StepStatus.Skipped)
 }
 case class ProjectSummary(
     projectName: String,
@@ -196,10 +208,10 @@ case class ProjectSummary(
     projectsSummary.partition(_.hasFailure)
 }
 
-given Conversion[String, ModuleBuildResult] = _ match {
-  case "ok"      => ModuleBuildResult.Ok
-  case "failed"  => ModuleBuildResult.Failed
-  case "skipped" => ModuleBuildResult.Skipped
+given Conversion[String, StepStatus] = _ match {
+  case "ok"      => StepStatus.Ok
+  case "failed"  => StepStatus.Failed
+  case "skipped" => StepStatus.Skipped
 }
 
 given HitReader[ProjectSummary] = (hit: Hit) => {
@@ -209,18 +221,29 @@ given HitReader[ProjectSummary] = (hit: Hit) => {
       case "failure" => BuildStatus.Failure
       case "success" => BuildStatus.Success
     }
+
     val modulesSummary =
-      for
-        modueleSource <- source("summary")
-          .asInstanceOf[List[Map[String, String]]]
-      yield ModuleSummary(
-        name = modueleSource("module"),
-        compile = modueleSource("compile"),
-        doc = modueleSource("doc"),
-        testsCompile = modueleSource("test-compile"),
-        tests = modueleSource("test"),
-        publish = modueleSource("publish")
-      )
+      for moduleSource <- source("summary").asInstanceOf[List[Map[String, AnyRef]]]
+      yield
+        def fromMap[T](field: String)(using conv: FromMap[T]) =
+          moduleSource.get(field) match {
+            case Some(m: Map[_, _]) =>
+              conv.fromMap(m.asInstanceOf[Map[String, AnyRef]]) match {
+                case Right(value) => value
+                case Left(reason) => sys.error(s"Cannot decode '$field', reason: ${reason}")
+              }
+            case Some(m) => sys.error(s"Field '$field' is not a map: ${m}")
+            case None    => sys.error(s"No field with name '$field'")
+          }
+
+        ModuleSummary(
+          name = moduleSource("module").toString,
+          compile = fromMap[CompileResult]("compile"),
+          doc = fromMap[DocsResult]("doc"),
+          testsCompile = fromMap[CompileResult]("test-compile"),
+          tests = fromMap[TestsResult]("test"),
+          publish = fromMap[PublishResult]("publish")
+        )
     ProjectSummary(
       projectName = source("projectName").toString.replaceFirst("_", "/"),
       version = source("version").toString,
@@ -230,6 +253,54 @@ given HitReader[ProjectSummary] = (hit: Hit) => {
       projectsSummary = modulesSummary
     )
   }
+}
+
+sealed trait FromMap[T]:
+  import FromMap.*
+  def fromMap(source: SourceMap): Result[T]
+
+object FromMap {
+  type SourceMap = Map[String, AnyRef]
+  type Result[T] = Either[FromMap.ConversionFailure, T]
+  sealed trait ConversionFailure
+  case class FieldMissing(field: String) extends ConversionFailure
+  case class IncorrectMapping(expected: Class[_], got: Class[_]) extends ConversionFailure
+
+  extension (source: SourceMap) {
+    def field(name: String): Result[AnyRef] =
+      source.get(name).toRight(left = FieldMissing(name))
+    def mapTo[T: FromMap]: Result[T] = summon[FromMap[T]].fromMap(source)
+  }
+
+  extension (value: Result[AnyRef]) {
+    inline def as[T: ClassTag]: Result[T] = value.flatMap {
+      case instance: T => Right(instance.asInstanceOf[T])
+      case other =>
+        Left(IncorrectMapping(expected = summon[ClassTag[T]].runtimeClass, got = other.getClass))
+    }
+  }
+
+  given FromMap[CompileResult] with
+    def fromMap(source: SourceMap): Result[CompileResult] =
+      for status <- source.field("status").as[String]
+      yield CompileResult(status = status: StepStatus)
+
+  given FromMap[DocsResult] with
+    def fromMap(source: SourceMap): Result[DocsResult] =
+      for status <- source.field("status").as[String]
+      yield DocsResult(status = status: StepStatus)
+
+  given FromMap[TestsResult] with
+    def fromMap(source: SourceMap): Result[TestsResult] =
+      for status <- source.field("status").as[String]
+      yield TestsResult(
+        status = status: StepStatus
+      )
+
+  given FromMap[PublishResult] with
+    def fromMap(source: SourceMap): Result[PublishResult] =
+      for status <- source.field("status").as[String]
+      yield PublishResult(status: StepStatus)
 
 }
 

--- a/jenkins/scripts/buildReport.scala
+++ b/jenkins/scripts/buildReport.scala
@@ -104,23 +104,22 @@ def showBuildReport(report: BuildReport): String =
   val Ident3 = Ident * 3
 
   def showSuccessfullProject(project: ProjectSummary) =
-    val ProjectSummary(name, version, _, _, modules) = project
+    val ProjectSummary(name, version, _, _, _, modules) = project
     s"""$Ident+ $name: Version: $version""".stripMargin
 
   def showFailedProject(project: ProjectSummary) =
-    val ProjectSummary(name, version, _, _, modules) = project
+    val ProjectSummary(name, version, _, _, buildUrl, modules) = project
     def showModules(label: String, results: Seq[ModuleSummary])(
         show: ModuleSummary => String
-    ) = 
+    ) =
       s"${Ident2}$label modules: ${results.size}" + {
         if results.isEmpty then ""
         else results.map(show).mkString("\n", "\n", "")
       }
     s"""$Ident- $name
        |${Ident2}Version: $version
-       |${showModules("Successfull", project.successfullModules)(m =>
-      s"$Ident2+ ${m.name}"
-    )}
+       |${Ident2}Build URL: $buildUrl
+       |${showModules("Successfull", project.successfullModules)(m => s"$Ident2+ ${m.name}")}
        |${showModules("Failed", project.failedModules)(showFailedModule(_))}
        |""".stripMargin
 
@@ -190,6 +189,7 @@ case class ProjectSummary(
     version: String,
     scalaVersion: String,
     status: BuildStatus,
+    buildUrl: String,
     projectsSummary: List[ModuleSummary]
 ) {
   lazy val (failedModules, successfullModules) =
@@ -226,6 +226,7 @@ given HitReader[ProjectSummary] = (hit: Hit) => {
       version = source("version").toString,
       scalaVersion = source("scalaVersion").toString,
       status = status,
+      buildUrl = source("buildURL").toString,
       projectsSummary = modulesSummary
     )
   }

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -145,7 +145,7 @@ pipeline {
                                         def timestamp = java.time.LocalDateTime.now()
                                         def buildStatus = getBuildStatus()
                                         0 == sh (
-                                          script: "/build/feed-elastic.sh '${params.elasticSearchUrl}' '${params.projectName}' '${buildStatus}' '${timestamp}' build-summary.txt build-logs.txt '${params.version}' '${params.scalaVersion}' '${params.buildName}'",
+                                          script: "/build/feed-elastic.sh '${params.elasticSearchUrl}' '${params.projectName}' '${buildStatus}' '${timestamp}' build-summary.txt build-logs.txt '${params.version}' '${params.scalaVersion}' '${params.buildName}' '${BUILD_URL}'",
                                           returnStatus: true
                                         )
                                     } else true

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -145,7 +145,7 @@ pipeline {
                                         def timestamp = java.time.LocalDateTime.now()
                                         def buildStatus = getBuildStatus()
                                         0 == sh (
-                                          script: "/build/feed-elastic.sh '${params.elasticSearchUrl}' '${params.projectName}' '${buildStatus}' '${timestamp}' build-summary.txt build-logs.txt '${params.version}' '${params.scalaVersion}' '${params.buildName}' '${BUILD_URL}'",
+                                          script: "/build/feed-elastic.sh '${params.elasticSearchUrl}' '${params.projectName}' '${buildStatus}' '${timestamp}' build-summary.txt build-logs.txt '${params.version}' '${params.scalaVersion}' '${params.buildName}' '${env.BUILD_URL}'",
                                           returnStatus: true
                                         )
                                     } else true

--- a/kibana/mappings/projectBuildSummary.json
+++ b/kibana/mappings/projectBuildSummary.json
@@ -11,6 +11,7 @@
         }
       },
       "buildId": {"type": "keyword"},
+      "buildURL": {"type": "text"},
       "timestamp": {"type": "date"},
       "version": {"type": "version"},
       "scalaVersion": {"type": "version"},

--- a/kibana/mappings/projectBuildSummary.json
+++ b/kibana/mappings/projectBuildSummary.json
@@ -1,6 +1,5 @@
 {
   "mappings": {
-    "dynamic": false,
     "properties": {
       "projectName": {
         "type": "text",
@@ -11,21 +10,11 @@
           }
         }
       },
-      "buildId": {
-        "type": "keyword"
-      },
-      "timestamp": {
-        "type": "date"
-      },
-      "version": {
-        "type": "version"
-      },
-      "scalaVersion": {
-        "type": "version"
-      },
-      "status": {
-        "type": "keyword"
-      },
+      "buildId": {"type": "keyword"},
+      "timestamp": {"type": "date"},
+      "version": {"type": "version"},
+      "scalaVersion": {"type": "version"},
+      "status": {"type": "keyword"},
       "summary": {
         "type": "nested", 
         "properties": {
@@ -39,25 +28,53 @@
             }
           },
           "compile": {
-            "type": "keyword"
+            "properties": {
+              "status": {"type": "keyword"},
+              "failureContext": {"properties": {"type": {"type": "keyword"}, "reasons": {"type": "text"}}},
+              "tookMs": {"type": "integer"},
+              "warnings": {"type": "short"},
+              "errors": {"type": "short"}
+            }
           },
           "doc": {
-            "type": "keyword"
-          },
-          "publish": {
-            "type": "keyword"
-          },
-          "test": {
-            "type": "keyword"
+            "properties": {
+              "status": {"type": "keyword"},
+              "failureContext": {"properties": {"type": {"type": "keyword"}, "reasons": {"type": "text"}}},
+              "tookMs": {"type": "integer"},
+              "files": {"type": "short"},
+              "totalSizeKb": {"type": "integer"}
+            }
           },
           "test-compile": {
-            "type": "keyword"
+            "properties": {
+              "status": {"type": "keyword"},
+              "failureContext": {"properties": {"type": {"type": "keyword"}, "reasons": {"type": "text"}}},
+              "tookMs": {"type": "integer"},
+              "warnings": {"type": "short"},
+              "errors": {"type": "short"}
+            }
+          },
+          "test": {
+            "properties": {
+              "status": {"type": "keyword"},
+              "failureContext": {"properties": {"type": {"type": "keyword"}, "reasons": {"type": "text"}}},
+              "tookMs": {"type": "integer"},
+              "passed": {"type": "integer"},
+              "failed": {"type": "short"},
+              "ignored": {"type": "short"},
+              "skipped": {"type": "short"}
+            }
+          },
+          "publish": {
+            "properties": {
+              "status": {"type": "keyword"},
+              "failureContext": {"type": "text"},
+              "tookMs": {"type": "integer"}
+            }
           }
         }
       },
-      "logs": {
-        "type": "text"
-      }
+      "logs": { "type": "text" }
     }
   }
 }

--- a/project-builder/Dockerfile
+++ b/project-builder/Dockerfile
@@ -2,10 +2,9 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 RUN apt install -y jq
 ENV PATH="/root/.local/share/coursier/bin:${PATH}"
-# Version 0.10.0 of mill seemed to have some problems when running locally
 RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs \ 
   && chmod +x cs \
-  && ./cs install mill:0.9.12 scalafix \
+  && ./cs install mill:0.10.2 scalafix \
   && sh -c "mill --version" \ 
   && sh -c "scalafix --version"
 

--- a/project-builder/feed-elastic.sh
+++ b/project-builder/feed-elastic.sh
@@ -15,7 +15,7 @@ logsFile="$6"
 version="$7"
 scalaVersion="$8"
 buildId="$9"
-buildUrl="$10"
+buildUrl="${10}"
 
 buildSummary="$(cat ${buildSummaryFile})"
 

--- a/project-builder/feed-elastic.sh
+++ b/project-builder/feed-elastic.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ $# -ne 9 ]; then
+if [ $# -ne 10 ]; then
   echo "Wrong number of script arguments, got $#, expected 7"
   exit 1
 fi
@@ -15,6 +15,7 @@ logsFile="$6"
 version="$7"
 scalaVersion="$8"
 buildId="$9"
+buildUrl="$10"
 
 buildSummary="$(cat ${buildSummaryFile})"
 
@@ -25,9 +26,10 @@ json=$(jq -n \
           --arg ver "$version" \
           --arg scVer "$scalaVersion" \
           --arg buildId "$buildId" \
+          --arg buildURL "$buildUrl" \
           --argjson sum "$buildSummary" \
           --rawfile logs "$logsFile" \
-          '{projectName: $pn, version: $ver, scalaVersion: $scVer, status: $res, timestamp: $ts, buildId: $buildId, summary: $sum, logs: $logs}')
+          '{projectName: $pn, version: $ver, scalaVersion: $scVer, status: $res, timestamp: $ts, buildId: $buildId, buildURL: $buildURL, summary: $sum, logs: $logs}')
 
 jsonFile=$(mktemp /tmp/feed-elastic-tmp.XXXXXX)
 

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -30,6 +30,8 @@ import scalalib.api.CompilationResult
 import mill.eval._
 import mill.define.{Cross => DefCross, _}
 import mill.define.Segment._
+// In mill 0.10.x moved from mill.scalalib
+// import mill.testrunner.TestRunner
 import requests._
 import coursier.maven.MavenRepository
 import coursier.Repository

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -418,7 +418,7 @@ object serialization {
   implicit lazy val TestingModeRW: ReadWriter[TestingMode] = {
     import TestingMode._
     val DisabledString = "disabled"
-    val CompileOnlyString = "compile-only "
+    val CompileOnlyString = "compile-only"
     val FullString = "full"
     def toJson(x: TestingMode): String = x match {
       case Disabled    => DisabledString

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -30,8 +30,7 @@ import scalalib.api.CompilationResult
 import mill.eval._
 import mill.define.{Cross => DefCross, _}
 import mill.define.Segment._
-// In mill 0.10.x moved from mill.scalalib
-// import mill.testrunner.TestRunner
+import mill.testrunner.TestRunner
 import requests._
 import coursier.maven.MavenRepository
 import coursier.Repository

--- a/project-builder/mill/build.sh
+++ b/project-builder/mill/build.sh
@@ -32,5 +32,4 @@ millSettings=(
   $(echo $projectConfig | jq -r '.mill?.options? // [] | join(" ")' | sed "s/<SCALA_VERSION>/${scalaVersion}/g")
 )
 
-# Make sure to use Mill 0.9.12, 0.10.x series contains breaking changes
-MILL_VERSION=0.9.12 mill ${millSettings[@]} runCommunityBuild "$scalaVersion" "${projectConfig}" "${targets[@]}"
+MILL_VERSION=0.10.2 mill ${millSettings[@]} runCommunityBuild "$scalaVersion" "${projectConfig}" "${targets[@]}"

--- a/project-builder/mill/build.sh
+++ b/project-builder/mill/build.sh
@@ -32,4 +32,5 @@ millSettings=(
   $(echo $projectConfig | jq -r '.mill?.options? // [] | join(" ")' | sed "s/<SCALA_VERSION>/${scalaVersion}/g")
 )
 
-mill ${millSettings[@]} runCommunityBuild "$scalaVersion" "${projectConfig}" "${targets[@]}"
+# Make sure to use Mill 0.9.12, 0.10.x series contains breaking changes
+MILL_VERSION=0.9.12 mill ${millSettings[@]} runCommunityBuild "$scalaVersion" "${projectConfig}" "${targets[@]}"

--- a/project-builder/mill/prepare-project.sh
+++ b/project-builder/mill/prepare-project.sh
@@ -26,4 +26,5 @@ cp repo/build.sc repo/build.scala \
     --scala-version 3.1.0 > repo/build.sc \
   && rm repo/build.scala 
 
+ln -fs $scriptDir/../shared/CommunityBuildCore.scala $repoDir/CommunityBuildCore.sc
 ln -fs $scriptDir/MillCommunityBuild.sc $repoDir/MillCommunityBuild.sc

--- a/project-builder/sbt/prepare-project.sh
+++ b/project-builder/sbt/prepare-project.sh
@@ -49,6 +49,7 @@ scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # Register command for setting up version, for more info check command impl comments
 echo -e "\ncommands += CommunityBuildPlugin.setPublishVersion\n" >>$repoDir/build.sbt
 
+ln -fs $scriptDir/../shared/CommunityBuildCore.scala $repoDir/project/CommunityBuildCore.scala
 ln -fs $scriptDir/CommunityBuildPlugin.scala $repoDir/project/CommunityBuildPlugin.scala
 
 # Project dependencies

--- a/project-builder/shared/CommunityBuildCore.scala
+++ b/project-builder/shared/CommunityBuildCore.scala
@@ -90,7 +90,7 @@ case class DocsResult(
 object DocsResult {
   def apply(evalResult: EvalResult[File]): DocsResult = {
     evalResult match {
-      case EvalResult.Value(targetDir, tookTime) =>
+      case EvalResult.Value(targetDir, tookTime) if targetDir.exists() =>
         case class Stats(files: Int, totalSize: Long)
         val stats = Files
           .walk(targetDir.toPath())

--- a/project-builder/shared/CommunityBuildCore.scala
+++ b/project-builder/shared/CommunityBuildCore.scala
@@ -187,7 +187,13 @@ object TaskEvaluator {
 
     def toBuildError: Option[FailureContext.BuildError] = this match {
       case EvalResult.Failure(reasons, _) =>
-        Some(FailureContext.BuildError(reasons.map(v => "\"" + v.toString + "\"").distinct))
+        Some(
+          FailureContext.BuildError(
+            reasons
+              .map(v => "\"" + v.toString.replace("\n", " \\n") + "\"")
+              .distinct
+          )
+        )
       case _ => None
     }
   }

--- a/project-builder/shared/CommunityBuildCore.scala
+++ b/project-builder/shared/CommunityBuildCore.scala
@@ -1,0 +1,259 @@
+import scala.collection.JavaConverters._
+import java.nio.file.Files
+import java.io.File
+
+import TaskEvaluator.EvalResult
+import scala.util.matching.Regex
+
+// Community projects configs
+case class ProjectBuildConfig(
+    projects: ProjectsConfig = ProjectsConfig(),
+    tests: TestingMode = TestingMode.Full
+)
+
+case class ProjectOverrides(tests: Option[TestingMode] = None)
+case class ProjectsConfig(
+    exclude: List[String] = Nil,
+    overrides: Map[String, ProjectOverrides] = Map.empty
+)
+
+sealed trait TestingMode
+object TestingMode {
+  case object Disabled extends TestingMode
+  case object CompileOnly extends TestingMode
+  case object Full extends TestingMode
+}
+
+// Output
+case class BuildSummary(results: Seq[ModuleBuildResults]) {
+  lazy val toJson: String = results
+    .map(_.toJson)
+    .mkString("[", ",", "]")
+}
+
+case class ModuleBuildResults(
+    artifactName: String,
+    compile: CompileResult,
+    doc: DocsResult,
+    testsCompile: CompileResult,
+    testsExecute: TestsResult,
+    publish: PublishResult
+) {
+  def hasFailedStep: Boolean = this.productIterator.exists {
+    case result: StepResult => result.status == Status.Failed
+    case _                  => false
+  }
+  lazy val toJson = {
+    s"""{
+       | "module": "$artifactName",
+       | "compile": ${compile.toJson},
+       | "doc": ${doc.toJson},
+       | "test-compile": ${testsCompile.toJson},
+       | "test": ${testsExecute.toJson},
+       | "publish": ${publish.toJson}
+       |}""".stripMargin
+  }
+}
+
+sealed trait StepResult {
+  def status: Status
+  def tookMs: Int
+  def failureContext: Option[FailureContext]
+  def toJson: String
+
+  protected def commonJsonFields: String = {
+    val optFailureCtxJson = failureContext.fold("")(ctx => s""""failureContext": ${ctx.toJson}, """)
+    s""""status": ${status.toJson}, ${optFailureCtxJson}"tookMs": ${tookMs}"""
+  }
+}
+case class CompileResult(
+    status: Status,
+    failureContext: Option[FailureContext] = None,
+    warnings: Int,
+    errors: Int,
+    tookMs: Int
+) extends StepResult {
+  def toJson =
+    s"""{$commonJsonFields, "warnings": ${warnings}, "errors": ${errors}}"""
+}
+
+case class DocsResult(
+    status: Status,
+    failureContext: Option[FailureContext] = None,
+    files: Int,
+    totalSizeKb: Int,
+    tookMs: Int
+) extends StepResult {
+  def toJson =
+    s"""{$commonJsonFields, "files": ${files}, "totalSizeKb": ${totalSizeKb}}"""
+}
+object DocsResult {
+  def apply(evalResult: EvalResult[File]): DocsResult = {
+    evalResult match {
+      case EvalResult.Value(targetDir, tookTime) =>
+        case class Stats(files: Int, totalSize: Long)
+        val stats = Files
+          .walk(targetDir.toPath())
+          .filter(Files.isRegularFile(_))
+          .iterator()
+          .asScala
+          .foldLeft(Stats(0, 0L)) { case (stats, path) =>
+            stats.copy(
+              files = stats.files + 1,
+              totalSize = stats.totalSize + Files.size(path)
+            )
+          }
+        DocsResult(
+          Status.Ok,
+          files = stats.files,
+          totalSizeKb = (stats.totalSize / 1024L).toInt,
+          tookMs = tookTime
+        )
+      case _ =>
+        DocsResult(
+          evalResult.toStatus,
+          failureContext = evalResult.toBuildError,
+          files = 0,
+          totalSizeKb = 0,
+          tookMs = evalResult.evalTime
+        )
+    }
+  }
+}
+case class TestsResult(
+    status: Status,
+    failureContext: Option[FailureContext] = None,
+    passed: Int,
+    failed: Int,
+    ignored: Int,
+    skipped: Int,
+    tookMs: Int
+) extends StepResult {
+  def toJson =
+    s"""{$commonJsonFields, "passed": ${passed}, "failed": ${failed}, "ignored": ${ignored}, "skipped": ${skipped}}"""
+}
+case class PublishResult(status: Status, failureContext: Option[FailureContext] = None, tookMs: Int)
+    extends StepResult {
+  def toJson = s"""{$commonJsonFields}"""
+}
+object PublishResult {
+  def apply(evalResult: TaskEvaluator.EvalResult[Unit]): PublishResult = {
+    PublishResult(
+      evalResult.toStatus,
+      failureContext = evalResult.toBuildError,
+      tookMs = evalResult.evalTime
+    )
+  }
+}
+
+sealed abstract class Status(stringValue: String) {
+  def toJson: String = s""""$stringValue""""
+}
+object Status {
+  case object Ok extends Status("ok")
+  case object Skipped extends Status("skipped")
+  case object Failed extends Status("failed")
+}
+
+sealed trait FailureContext {
+  def toJson: String
+}
+object FailureContext {
+  case class WrongVersion(expected: String, actual: String) extends FailureContext {
+    override def toJson: String =
+      s"""{"type": "wrongVersion", "expected": "$expected", "actual": "$actual"}"""
+  }
+  case class BuildError(reasons: List[String]) extends FailureContext {
+    override def toJson: String =
+      s"""{"type": "buildError", "reasons": ${reasons.mkString("[", ", ", "]")}}"""
+  }
+}
+
+object TaskEvaluator {
+  type Milliseconds = Int
+  sealed trait EvalResult[+T] {
+    def evalTime: Milliseconds
+
+    def map[U](fn: T => U): EvalResult[U] = this match {
+      case EvalResult.Value(value, tookMs) => EvalResult.Value(fn(value), tookMs)
+      case other                           => other.asInstanceOf[EvalResult[U]]
+    }
+
+    def toStatus: Status = this match {
+      case _: EvalResult.Value[_] => Status.Ok
+      case _: EvalResult.Failure  => Status.Failed
+      case EvalResult.Skipped     => Status.Skipped
+    }
+
+    def toBuildError: Option[FailureContext.BuildError] = this match {
+      case EvalResult.Failure(reasons, _) =>
+        Some(FailureContext.BuildError(reasons.map(v => "\"" + v.toString + "\"").distinct))
+      case _ => None
+    }
+  }
+  object EvalResult {
+    case class Value[+T](value: T, evalTime: Milliseconds) extends EvalResult[T]
+    case class Failure(reasons: List[Throwable], evalTime: Milliseconds) extends EvalResult[Nothing]
+    case object Skipped extends EvalResult[Nothing] {
+      override final val evalTime: Milliseconds = 0
+    }
+    def skipped: EvalResult[Nothing] = Skipped
+  }
+
+  sealed trait EvaluationException extends Exception
+  case class UnkownTaskException(taskName: String) extends EvaluationException
+  case class EvaluationFailure(msg: String) extends EvaluationException
+}
+
+abstract class TaskEvaluator[Task[_]] {
+  import TaskEvaluator._
+  def eval[T](task: Task[T]): EvalResult[T]
+
+  def evalWhen[T](predicate: => Boolean, dependencies: EvalResult[_]*)(
+      task: Task[T]
+  ): EvalResult[T] = {
+    if (predicate) evalAsDependencyOf(dependencies: _*)(task)
+    else EvalResult.Skipped
+  }
+
+  def evalAsDependencyOf[T](
+      dependencies: EvalResult[_]*
+  )(task: Task[T]): EvalResult[T] = {
+    val shouldSkip = dependencies.exists {
+      case _: EvalResult.Value[_] => false
+      case _                      => true
+    }
+    if (shouldSkip) EvalResult.Skipped
+    else eval(task)
+  }
+}
+
+class ProjectBuildFailureException
+    extends Exception("At least 1 subproject finished with failures") {
+  // Don't collect stack trace
+  override def fillInStackTrace(): Throwable = this
+}
+
+object Utils {
+  def filterTargets(targets: Seq[String], excludedPatterns: Seq[Regex]) = {
+    targets.filter { target =>
+      target.split('%') match {
+        case Array(org, name) =>
+          val excludingPattern = excludedPatterns.find { pattern =>
+            // No Regex.matches in Scala 2.12 (!sic)
+            pattern
+              .findFirstIn(name)
+              .orElse(pattern.findFirstIn(target))
+              .isDefined
+          }
+          excludingPattern.foreach { pattern =>
+            println(s"Excluding target '$target' - matches exclusion rule: '${pattern}'")
+          }
+          excludingPattern.isEmpty
+        case _ =>
+          println(s"Excluding target '$target' - incompatible format")
+          false
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new model of build results, which is able to gather additional build information, eg. number of warnings, errors, etc. Additionally it introduces shared model between sbt and mill builds

Partially implementers #12 

* Move common code between build tool implementations to CommunityBuildCore.scala
* Introduced task-specific results gathering additional information
* Pass BUILD_URL to elasticsearch reports and show them in the reports for failed projects
* Adjust ES mappings to the new model