### PR TITLE
Improved setup of project publish version in sbt

### DIFF
--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -33,8 +33,11 @@ virtuslab:scala-cli:.*
 
 # Failure on project init
 zio:zio-aws:.*
+dmurvihill:courier:.*
+
 # Incorrect upstream version due to using dotty-staging/zio
 zio:interop-cats:.*  
+zio:zio-kafka:.*
 dream11:zio-http:.*
 
 # Missing defintions of DelayedReadChannel

--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -31,6 +31,12 @@ zio:zio-query:.*
 # Too complex mill build
 virtuslab:scala-cli:.*
 
+# Failure on project init
+zio:zio-aws:.*
+# Incorrect upstream version due to using dotty-staging/zio
+zio:interop-cats:.*  
+dream11:zio-http:.*
+
 # Missing defintions of DelayedReadChannel
 rssh:scala-gopher:.*
 

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -83,6 +83,7 @@ http4s_http4s {
     """set blazeClient/ Test/unmanagedSources/excludeFilter := HiddenFileFilter || "BlazeClientSuite.scala" || "BlazeHttp1ClientSuite.scala" || "ClientTimeoutSuite.scala""""
     """set blazeServer/ Test/unmanagedSources/excludeFilter := HiddenFileFilter || "Http1ServerStageSpec.scala""""
     """set tomcatServer/Test/unmanagedSources/excludeFilter := HiddenFileFilter || "TomcatServerSuite.scala""""
+    "set every unidoc/unidocAllSources := Nil" // unidoc sometimes leads to deadlock/timeout when run in container
   ]
 }
 
@@ -246,10 +247,6 @@ wvlet_airframe {
       airframe.tests = compile-only
     }
   }
-}
-
-zio_zio-aws {
-  sbt.options=["-J-XX:+UseG1GC" "-J-Xmx6g" "-J-Xms6g" "-J-Xss16m"]
 }
 
 zio_zio-quill {

--- a/env/prod/config/projects-config.conf
+++ b/env/prod/config/projects-config.conf
@@ -30,6 +30,9 @@ disneystreaming_smithy4s {
     smithy4s-dynamic.tests = compile-only
   }
 }
+disneystreaming_weaver-test {
+  sbt.options=["-Dcommunitybuild.dualVersion=minor:+1"]
+}
 
 etorreborre_specs2 {
   projects{
@@ -229,6 +232,8 @@ thoughtworksinc_binding.scala {
     "com.thoughtworks.binding%streamt"
   ]
 }
+
+unibas-gravis_scalismo.tests = compile-only // Uses native library
 
 wvlet_airframe {
   projects{

--- a/kibana/mappings/projectBuildSummary.json
+++ b/kibana/mappings/projectBuildSummary.json
@@ -69,7 +69,7 @@
           "publish": {
             "properties": {
               "status": {"type": "keyword"},
-              "failureContext": {"type": "text"},
+              "failureContext": {"properties": {"type": {"type": "keyword"}, "reasons": {"type": "text"}}},
               "tookMs": {"type": "integer"}
             }
           }

--- a/project-builder/sbt/build.sh
+++ b/project-builder/sbt/build.sh
@@ -44,6 +44,7 @@ logFile=build.log
 
 function runSbt() {
   # Use `setPublishVersion` instead of `every version`, as it might overrte Jmh/Jcstress versions
+  # set every ... might lead to restoring original version changed in setPublishVersion
   forceScalaVersion=$1
   setScalaVersionCmd="++$scalaVersion"
   if [[ "$forceScalaVersion" == "forceScala" ]]; then
@@ -52,9 +53,9 @@ function runSbt() {
   tq='"""'
   sbt ${sbtSettings[@]} \
     "$setScalaVersionCmd -v" \
-    "setPublishVersion $version" \
     "set every credentials := Nil" \
     "$customCommands" \
+    "setPublishVersion $version" \
     "moduleMappings" \
     "runBuild ${scalaVersion} ${tq}${projectConfig}${tq} $targetsString" | tee $logFile
 }


### PR DESCRIPTION
* Fixes problems with setting proper version in projects using project-matrix plugins
* Allow for dual-versioning of builds (when some of the modules are published with different version)
* Update configs