### PR TITLE
Improve throughput when building plan

### DIFF
--- a/coordinator/src/main/scala/buildPlan.scala
+++ b/coordinator/src/main/scala/buildPlan.scala
@@ -52,7 +52,7 @@ def stripScala3Suffix(s: String) = s match { case WithExtractedScala3Suffix(pref
 
 def buildPlanCommons(depGraph: DependencyGraph) =
   val data = depGraph.projects
-  val topLevelData = data.filter(_.p.stars > 100)
+  val topLevelData = data
 
   val fullInfo = data.map(l => l.p -> l).toMap
 
@@ -242,7 +242,6 @@ def makeDependenciesBasedBuildPlan(
       repoUrl: String,
       tagOrRevision: Option[String]
   ): Option[ProjectBuildConfig] = {
-    println(s"Load project config ${project.p.show} @ ${project.v}")
     val name = projectName(project)
     val projectDir = os.temp.dir(prefix = s"repo-$name")
     os.proc(
@@ -400,6 +399,7 @@ private given FromString[Seq[Project]] = str =>
   import java.nio.file._
   val dataPath = Paths.get("data")
   val dest = dataPath.resolve("buildPlan.json")
-  val json = toJson(plan)
+  println("Projects in build plan: " + plan.size)
+  val json = toJson(plan.sortBy(_.dependencies.size))
   Files.createDirectories(dest.getParent)
   Files.write(dest, json.toString.getBytes)

--- a/coordinator/src/main/scala/buildPlan.scala
+++ b/coordinator/src/main/scala/buildPlan.scala
@@ -242,6 +242,7 @@ def makeDependenciesBasedBuildPlan(
       repoUrl: String,
       tagOrRevision: Option[String]
   ): Option[ProjectBuildConfig] = {
+    println(s"Load project config ${project.p.show} @ ${project.v}")
     val name = projectName(project)
     val projectDir = os.temp.dir(prefix = s"repo-$name")
     os.proc(
@@ -261,9 +262,10 @@ def makeDependenciesBasedBuildPlan(
         .load[ProjectBuildConfig]
 
       config.left.foreach {
-        case ConfigReaderFailures(
-              CannotReadFile(_, Some(_: java.io.FileNotFoundException))
-            ) =>
+        case reasons: ConfigReaderFailures if reasons.toList.exists {
+              case CannotReadFile(_, Some(_: java.io.FileNotFoundException)) => true
+              case _                                                         => false
+            } =>
           ()
         case reason =>
           System.err.println(

--- a/coordinator/src/main/scala/deps.scala
+++ b/coordinator/src/main/scala/deps.scala
@@ -171,8 +171,9 @@ def loadDepenenecyGraph(
   val projects = {
     val loadProjects = Future.traverse((required #::: optional).zipWithIndex) { (project, idx) =>
       Future {
+        val name = s"${project.project.org}/${project.project.name}"
         println(
-          s"Load maven info: #${idx}${maxProjectsCount.map("/" + _)} - ${project.project.show}"
+          s"Load Maven info: #${idx}${maxProjectsCount.fold("")("/" + _)} - $name"
         )
         Option(loadMavenInfo(scalaBinaryVersion)(project))
       }.recover {


### PR DESCRIPTION
* Parallelize loading information from Maven and Scaladex
* Improve handling of errors
* Don't filter projects when building the plan - filtering should be done only when fetching projects
* Improve logging
* Sort dependencies based plan by number of dependencies
* Run scalafmt