### PR TITLE
Migrate to new Scaladex API

### DIFF
--- a/coordinator/build.sbt
+++ b/coordinator/build.sbt
@@ -12,10 +12,10 @@ lazy val root = project
       "com.novocode" % "junit-interface" % "0.11" % "test",
       // Newer versions of jsoup up to 1.13.1 are buggy and cause missing versions of artifacts
       "org.jsoup" % "jsoup" % "1.10.3",
-      "net.sourceforge.htmlunit" % "htmlunit" % "2.29",
       "org.json4s" %% "json4s-native" % "4.0.4",
       "org.json4s" %% "json4s-ext" % "4.0.4",
       "com.github.pureconfig" %% "pureconfig-core" % "0.17.1",
-      "com.lihaoyi" %% "os-lib" % "0.8.0"
+      "com.lihaoyi" %% "os-lib" % "0.8.0",
+      "com.lihaoyi" %% "requests" % "0.7.0" 
     )
   )

--- a/coordinator/src/main/scala/Scaladex.scala
+++ b/coordinator/src/main/scala/Scaladex.scala
@@ -1,0 +1,54 @@
+import java.time.ZonedDateTime
+import scala.concurrent.*
+
+object Scaladex {
+  case class Pagination(current: Int, pageCount: Int, totalSize: Int)
+  case class ArtifactMetadata(version: String)
+  case class ArtifactMetadataResponse(pagination: Pagination, items: List[ArtifactMetadata])
+  case class ProjectSummary(
+      groupId: String,
+      artifacts: List[String], // List of artifacts with suffixes
+      version: String, // latest known versions
+      versions: List[String] // all published versions
+  )
+
+  final val ScaladexUrl = "https://index.scala-lang.org"
+  type AsyncResponse[T] = ExecutionContext ?=> Future[T]
+
+  def artifactMetadata(
+      groupId: String,
+      artifactId: String
+  ): AsyncResponse[ArtifactMetadataResponse] =
+    Future {
+      val response = requests.get(
+        url = s"$ScaladexUrl/api/artifacts/$groupId/$artifactId"
+      )
+      fromJson[ArtifactMetadataResponse](response.text())
+    }
+
+  def projectSummary(
+      organization: String,
+      repository: String,
+      scalaBinaryVersion: String
+  ): AsyncResponse[ProjectSummary] = Future {
+    val response = requests.get(
+      url = s"$ScaladexUrl/api/project",
+      params = Map(
+        "organization" -> organization,
+        "repository" -> repository,
+        "target" -> "JVM",
+        "scalaVersion" -> scalaBinaryVersion
+      )
+    )
+    println(Map(
+        "organization" -> organization,
+        "repository" -> repository,
+        "target" -> "JVM",
+        "scalaVersion" -> scalaBinaryVersion
+      ))
+    println(response)
+    println(response.text())
+    fromJson[ProjectSummary](response.text())
+  }
+
+}

--- a/coordinator/src/main/scala/Scaladex.scala
+++ b/coordinator/src/main/scala/Scaladex.scala
@@ -30,7 +30,7 @@ object Scaladex {
       organization: String,
       repository: String,
       scalaBinaryVersion: String
-  ): AsyncResponse[ProjectSummary] = Future {
+  ): AsyncResponse[Option[ProjectSummary]] = Future {
     val response = requests.get(
       url = s"$ScaladexUrl/api/project",
       params = Map(
@@ -40,15 +40,11 @@ object Scaladex {
         "scalaVersion" -> scalaBinaryVersion
       )
     )
-    println(Map(
-        "organization" -> organization,
-        "repository" -> repository,
-        "target" -> "JVM",
-        "scalaVersion" -> scalaBinaryVersion
-      ))
-    println(response)
-    println(response.text())
-    fromJson[ProjectSummary](response.text())
+    // If output is empty it means that given project does not define JVM modules
+    // for given scala version
+    Option.unless(response.contentLength.contains(0)) {
+      fromJson[ProjectSummary](response.text())
+    }
   }
 
 }

--- a/coordinator/src/main/scala/deps.scala
+++ b/coordinator/src/main/scala/deps.scala
@@ -32,54 +32,42 @@ def loadProjects(scalaBinaryVersion: String): Seq[Project] =
     .flatten
 
 case class ModuleInVersion(version: String, modules: Seq[String])
-
 case class ProjectModules(project: Project, mvs: Seq[ModuleInVersion])
 
-private def loadScaladexVersionsMatrix(project: Project) =
-  // Scaladex loads data dynamically using JS handlers
-  // We use htmlunit to execute handlers and get all the results
-  import com.gargoylesoftware.htmlunit
-  import htmlunit.*
-  import htmlunit.html.HtmlPage
-  import project.{org, name}
-  import java.util.logging.*
-
-  val url = s"https://index.scala-lang.org/artifacts/$org/$name"
-  val client = WebClient(BrowserVersion.CHROME)
-  def setOption(fn: WebClientOptions => Unit) = fn(client.getOptions())
-  setOption(_.setJavaScriptEnabled(true))
-  setOption(_.setCssEnabled(false))
-  setOption(_.setThrowExceptionOnScriptError(false))
-  setOption(_.setThrowExceptionOnFailingStatusCode(true))
-  setOption(_.setTimeout(15 * 1000))
-  // We set window size to trigger loading of all entries
-  client.getCurrentWindow.setInnerHeight(Int.MaxValue)
-  Logger.getLogger("com.gargoylesoftware").setLevel(Level.OFF)
-
-  val page = client.getPage[HtmlPage](url)
-  Jsoup.parse(page.asXml)
-
 def loadScaladexProject(scalaBinaryVersion: String)(project: Project): ProjectModules =
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import util.*
   val binaryVersionSuffix = "_" + scalaBinaryVersion
-  val d = loadScaladexVersionsMatrix(project)
-  val mvs =
-    for
-      table <- d.select("tbody").asScala.toSeq
-      version <- table.select(".version").asScala.map(_.text())
-    yield
-      val modules =
-        for
-          tr <- table.select("tr").asScala
-          if tr.attr("class").split(" ").contains(binaryVersionSuffix)
-          name = tr.select(".artifact").get(0).text.trim
-        yield name
-      ModuleInVersion(version, modules.toSeq)
+  val moduleVersionsTask = for
+    projectSummary <- Scaladex.projectSummary(project.org, project.name, scalaBinaryVersion)
+    artifactsMetadata <- Future
+      .traverse(projectSummary.artifacts) { artifact =>
+        Scaladex
+          .artifactMetadata(groupId = projectSummary.groupId, artifactId = s"${artifact}_3")
+          .map { response =>
+            if (response.pagination.pageCount != 1)
+              System.err.println(
+                "Scaladex now implementes pagination! Ignoring artifact metadata from additional pages"
+              )
+            val versions = response.items.map(_.version)
+            artifact -> versions
+          }
+      }
+      .map(_.toMap)
+  yield for version <- projectSummary.versions
+  yield ModuleInVersion(
+    version,
+    modules = artifactsMetadata.collect {
+      case (module, versions) if versions.contains(version) => module
+    }.toSeq
+  )
+  val moduleVersions = Await.result(moduleVersionsTask, 5.minute)
 
   // Make sure that versions are ordered, some libraries don't have correct order in scaladex matrix
   // Eg. scalanlp/breeze lists versions: 2.0, 2.0-RC1, 2.0.1-RC2, 2.0.1-RC1
   // We want to have latests versions in front of collection
   case class VersionedModules(modules: ModuleInVersion, semVersion: SemVersion)
-  val modules = mvs
+  val modules = moduleVersions
     .filter(_.modules.nonEmpty)
     .map(mvs => VersionedModules(mvs, mvs.version))
     .sortBy(_.semVersion)

--- a/coordinator/src/main/scala/encoding.scala
+++ b/coordinator/src/main/scala/encoding.scala
@@ -24,3 +24,4 @@ class TestingModeEnumSerializer
     })
 
 def toJson[T](obj: T): String = Serialization.write(obj)
+def fromJson[T: Manifest](json: String): T = Serialization.read(json)


### PR DESCRIPTION
Scaladex has removed the version matrix, since the latest version we can use a simple REST API to retrieve the needed informations