### PR TITLE
Allow to define simple patches for sources in the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,19 +93,19 @@ eval $(minikube -p minikube docker-env)
 Most likely you'll need to build the base image only once (it doesn't get modified too often but building it takes quite a lot of time), e.g.:
 
 ```shell
-scripts/build-builder-base.sh v0.0.8
+scripts/build-builder-base.sh v0.0.10
 ```
 
 Build all the remaining images
 
 ```shell
-scripts/build-quick.sh v0.0.8
+scripts/build-quick.sh v0.0.10
 ```
 
 or (re)build each image separately e.g.
 
 ```shell
-scripts/build-mvn-repo.sh v0.0.8
+scripts/build-mvn-repo.sh v0.0.10
 ```
 
 ### Deploying and debugging in k8s

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -27,7 +27,7 @@ given ExecutionContext = ExecutionContext.Implicits.global
 
 class FailedProjectException(msg: String) extends RuntimeException(msg) with NoStackTrace
 
-val communityBuildVersion = sys.props.getOrElse("communitybuild.version", "v0.0.8")
+val communityBuildVersion = sys.props.getOrElse("communitybuild.version", "v0.0.10")
 private val CBRepoName = "VirtusLab/community-build3"
 val projectBuilderUrl = s"https://raw.githubusercontent.com/$CBRepoName/master/project-builder"
 lazy val communityBuildDir = sys.props

--- a/coordinator/build.sbt
+++ b/coordinator/build.sbt
@@ -1,4 +1,4 @@
-val scala3Version = "3.1.1"
+val scala3Version = "3.1.2"
 
 lazy val root = project
   .in(file("."))

--- a/coordinator/src/main/resources/buildPlan.reference.conf
+++ b/coordinator/src/main/resources/buildPlan.reference.conf
@@ -41,3 +41,12 @@ sbt {
 
 // Hint for build coordinator informing about expected memory usage, typically Xmx from project opts
 memory-request-mb = 2048
+// List of patches to apply on the project sources before starting build in format:
+// { 
+//  path: String,        // Relative path to file within the project using Unix-like paths, eg. foo/bar.scala
+//  pattern: String      // Regex pattern to match text 
+//  replace-with: String // Replacement string to apply, can use constant values listed below
+// }
+// Allowed constant values: 
+// * SCALA_VERSION - Scala version that would be used to run the build
+source-patches = []

--- a/coordinator/src/main/scala/ProjectConfigDiscovery.scala
+++ b/coordinator/src/main/scala/ProjectConfigDiscovery.scala
@@ -25,6 +25,10 @@ class ProjectConfigDiscovery(internalProjectConfigsPath: java.io.File) {
           val discovered = discoverMemoryRequest(projectDir).filter(_ > default).getOrElse(default)
           c.copy(memoryRequestMb = discovered)
       }
+      .map { c =>
+        if c.sourcePatches.nonEmpty then c
+        else c.copy(sourcePatches = discoverSourcePatches(projectDir))
+      }
       .filter(_ != ProjectBuildConfig.empty)
       .map { config =>
         println(s"Using custom project config for $name: ${toJson(config)}")
@@ -58,6 +62,14 @@ class ProjectConfigDiscovery(internalProjectConfigsPath: java.io.File) {
         .stream(workflowsDir)
         .filter(file => file.ext.contains("yml") || file.ext.contains("yaml"))
         .toList
+  }
+
+  private def commonBuildFiles(projectDir: os.Path) = {
+    val files = projectDir / "build.sc" ::
+      projectDir / "build.sbt" ::
+      List(projectDir / "project").filter(os.exists(_)).flatMap(os.walk(_)).toList
+
+    files.filter(f => os.exists(f) && os.isFile(f))
   }
 
   private lazy val referenceConfig =
@@ -153,6 +165,42 @@ class ProjectConfigDiscovery(internalProjectConfigsPath: java.io.File) {
       .minOption
       .map(_.toString)
 
+  private def discoverSourcePatches(projectDir: os.Path): List[SourcePatch] =
+    object Scala3VersionDef {
+      case class Replecement(toMatch: String, replecement: String)
+      final val scala3VersionNames = List(
+        "Scala3", // https://github.com/zio/zio/blob/5e56f0e252477a3aef60140bd05ae4f20b4f8f39/project/BuildHelper.scala#L25
+        "scala3", // https://github.com/ghostdogpr/caliban/blob/95c5bafac4b8c72e5eb2af9b52b6cb7554a7da2d/build.sbt#L6
+        "Scala3Version",
+        "scala3Version" // https://github.com/47degrees/fetch/blob/c4732a827816c58ce84013e9580120bdc3f64bc6/build.sbt#L10
+      )
+      private def matchEnclosed(pattern: String) = s"(?:$pattern)".r
+      private val Scala3VersionNamesAlt = matchEnclosed(scala3VersionNames.mkString("|"))
+      private val DefOrVal = matchEnclosed("def|val|var")
+      private val OptType = matchEnclosed(raw":\s*String")
+      private val FullMatchPattern =
+        raw"(.*($DefOrVal $Scala3VersionNamesAlt$OptType)\s*=\s*(.*))".r
+      def unapply(line: String): Option[Replecement] = line match {
+        case FullMatchPattern(wholeDefn, definition, value) =>
+          Some(Replecement(wholeDefn, s"$definition = <SCALA_VERSION>"))
+        case _ => None
+      }
+    }
+    def scala3VersionDefs =
+      commonBuildFiles(projectDir).flatMap { file =>
+        import Scala3VersionDef.Replecement
+        os.read.lines(file).collect { case Scala3VersionDef(toMatch, replecement) =>
+          SourcePatch(
+            path = file.relativeTo(projectDir).toString,
+            pattern = toMatch,
+            replaceWith = replecement
+          )
+        }
+      }
+    end scala3VersionDefs
+    scala3VersionDefs
+  end discoverSourcePatches
+
   // Selects recommened amount of memory for project pod, based on the config files
   private def discoverMemoryRequest(projectDir: os.Path): Option[Int] =
     def readXmx(file: os.Path): Seq[Xmx.MegaBytes] =
@@ -170,13 +218,7 @@ class ProjectConfigDiscovery(internalProjectConfigsPath: java.io.File) {
       )
       .flatMap(readXmx)
 
-    val fromBuild =
-      val toCheck = projectDir / "build.sc" ::
-        projectDir / "build.sbt" ::
-        List(projectDir / "project").filter(os.exists(_)).flatMap(os.walk(_)).toList
-      toCheck
-        .filter(f => os.exists(f) && os.isFile(f))
-        .flatMap(readXmx)
+    val fromBuild = commonBuildFiles(projectDir).flatMap(readXmx)
 
     val allCandidates = fromOptsFiles ++ fromWorkflows ++ fromBuild
     allCandidates.maxOption

--- a/coordinator/src/main/scala/ProjectConfigDiscovery.scala
+++ b/coordinator/src/main/scala/ProjectConfigDiscovery.scala
@@ -179,7 +179,7 @@ class ProjectConfigDiscovery(internalProjectConfigsPath: java.io.File) {
       private val DefOrVal = matchEnclosed("def|val|var")
       private val OptType = matchEnclosed(raw":\s*String")
       private val FullMatchPattern =
-        raw"(.*($DefOrVal $Scala3VersionNamesAlt$OptType)\s*=\s*(.*))".r
+        raw".*(($DefOrVal $Scala3VersionNamesAlt$OptType)\s*=\s*(.*))".r
       def unapply(line: String): Option[Replecement] = line match {
         case FullMatchPattern(wholeDefn, definition, value) =>
           Some(Replecement(wholeDefn, s"$definition = <SCALA_VERSION>"))

--- a/coordinator/src/main/scala/core.scala
+++ b/coordinator/src/main/scala/core.scala
@@ -70,7 +70,7 @@ case class ProjectsConfig(
     overrides: Map[String, ProjectOverrides] = Map.empty
 ) derives ConfigReader
 // Describes a simple textual replecement performed on path (relative Unix-style path to the file
-case class SourcePatch(path: String, pattern: String, replecement: String) derives ConfigReader
+case class SourcePatch(path: String, pattern: String, replaceWith: String) derives ConfigReader
 case class ProjectBuildConfig(
     projects: ProjectsConfig = ProjectsConfig(),
     java: JavaConfig = JavaConfig(),

--- a/coordinator/src/main/scala/core.scala
+++ b/coordinator/src/main/scala/core.scala
@@ -69,6 +69,8 @@ case class ProjectsConfig(
     exclude: List[String] = Nil,
     overrides: Map[String, ProjectOverrides] = Map.empty
 ) derives ConfigReader
+// Describes a simple textual replecement performed on path (relative Unix-style path to the file
+case class SourcePatch(path: String, pattern: String, replecement: String) derives ConfigReader
 case class ProjectBuildConfig(
     projects: ProjectsConfig = ProjectsConfig(),
     java: JavaConfig = JavaConfig(),
@@ -76,7 +78,8 @@ case class ProjectBuildConfig(
     mill: MillConfig = MillConfig(),
     tests: TestingMode = TestingMode.Full,
     // We should use Option[Int] here, but json4s fails to resolve signature https://github.com/json4s/json4s/issues/1035
-    memoryRequestMb: Int = 2048
+    memoryRequestMb: Int = 2048,
+    sourcePatches: List[SourcePatch] = Nil
 ) derives ConfigReader
 
 object ProjectBuildConfig {

--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -17,28 +17,12 @@ com-lihaoyi:ammonite:.*
 jvican:dijon:.*
 
 # Build problems:
-# Checking Scala 3 using constant version string
-ghostdogpr:caliban:.*
-softwaremill:macwire:.*
-softwaremill:quicklens:.*
-47degrees:fetch:.*
-zio:zio-config:.*
-zio:zio-json:.*
-zio:zio-logging:.*
-zio:zio-nio:.*
-zio:zio-prelude:.*
-zio:zio-query:.*
 # Too complex mill build
 virtuslab:scala-cli:.*
 
 # Failure on project init
 zio:zio-aws:.*
 dmurvihill:courier:.*
-
-# Incorrect upstream version due to using dotty-staging/zio
-zio:interop-cats:.*  
-zio:zio-kafka:.*
-dream11:zio-http:.*
 
 # Missing defintions of DelayedReadChannel
 rssh:scala-gopher:.*

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -5,7 +5,6 @@ playframework/playframework dotty-staging/play-json
 scodec/scodec dotty-staging/scodec main
 scala/scala-swing scala/scala-swing v3.0.0#3.0.0
 spray/spray spray/spray-json v1.3.6-3.1.0
-zio/zio dotty-staging/zio resync-20220131
 
 # https://github.com/lampepfl/dotty/issues/14804
 tpolecat/doobie WojciechMazur/doobie fix/3.1.1-compat

--- a/env/prod/config/replaced-projects.txt
+++ b/env/prod/config/replaced-projects.txt
@@ -8,4 +8,3 @@ spray/spray spray/spray-json v1.3.6-3.1.0
 
 # https://github.com/lampepfl/dotty/issues/14804
 tpolecat/doobie WojciechMazur/doobie fix/3.1.1-compat
-softwaremill/tapir WojciechMazur/tapir fix/3.1.2-compat

--- a/jenkins/seeds/buildCommunityProject.groovy
+++ b/jenkins/seeds/buildCommunityProject.groovy
@@ -65,7 +65,7 @@ pipeline {
                               name: mvn-repo-cert
                           containers:
                           - name: project-builder
-                            image: virtuslab/scala-community-build-project-builder:jdk${params.javaVersion?: 11}-v0.0.8
+                            image: virtuslab/scala-community-build-project-builder:jdk${params.javaVersion?: 11}-v0.0.10
                             imagePullPolicy: IfNotPresent
                             volumeMounts:
                             - name: mvn-repo-cert

--- a/jenkins/seeds/buildCompiler.groovy
+++ b/jenkins/seeds/buildCompiler.groovy
@@ -33,7 +33,7 @@ pipeline {
                               name: mvn-repo-cert
                           containers:
                           - name: compiler-builder
-                            image: virtuslab/scala-community-build-compiler-builder:v0.0.8
+                            image: virtuslab/scala-community-build-compiler-builder:v0.0.10
                             imagePullPolicy: IfNotPresent
                             volumeMounts:
                             - name: mvn-repo-cert

--- a/jenkins/seeds/computeBuildPlan.groovy
+++ b/jenkins/seeds/computeBuildPlan.groovy
@@ -24,7 +24,7 @@ pipeline {
                         spec:
                           containers:
                           - name: coordinator
-                            image: virtuslab/scala-community-build-coordinator:v0.0.8
+                            image: virtuslab/scala-community-build-coordinator:v0.0.10
                             imagePullPolicy: IfNotPresent
                             command:
                             - cat

--- a/jenkins/seeds/runBuild.groovy
+++ b/jenkins/seeds/runBuild.groovy
@@ -179,7 +179,7 @@ pipeline {
         podTemplate(
           containers: [
             // Any container having a curl or pre-installed scala-cli would work 
-            containerTemplate(name: 'reporter', image: 'virtuslab/scala-community-build-coordinator:v0.0.8', command: 'sleep', args: '15m'),
+            containerTemplate(name: 'reporter', image: 'virtuslab/scala-community-build-coordinator:v0.0.10', command: 'sleep', args: '15m'),
           ],
           envVars: [
             envVar(key: 'ELASTIC_USERNAME', value: params.elasticSearchUserName),

--- a/k8s/mvn-repo.yaml
+++ b/k8s/mvn-repo.yaml
@@ -20,7 +20,7 @@ spec:
           secretName: mvn-repo-keystore
       containers:
       - name: mvn-repo
-        image: virtuslab/scala-community-build-mvn-repo:v0.0.8
+        image: virtuslab/scala-community-build-mvn-repo:v0.0.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081

--- a/project-builder/build-revision.sh
+++ b/project-builder/build-revision.sh
@@ -38,7 +38,7 @@ if [ -f "repo/mill" ] || [ -f "repo/build.sc" ]; then
 
 elif [ -f "repo/build.sbt" ]; then 
   echo "sbt project found: ${isSbtProject}"
-  $scriptDir/sbt/prepare-project.sh repo "$enforcedSbtVersion"
+  $scriptDir/sbt/prepare-project.sh repo "$enforcedSbtVersion" "$scalaVersion" "$projectConfig"
   $scriptDir/sbt/build.sh repo "$scalaVersion" "$version" "$targets" "$mvnRepoUrl" "$projectConfig"
 
 else

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -7,7 +7,7 @@ if [ $# -ne 1 ]; then
 fi
 
 VERSION="$1"
-export PREV_CB_VERSION="v0.0.9"
+export PREV_CB_VERSION="v0.0.10"
 
 javaDefault=11
 javaAccessoryVersions=(8 17)

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -7,7 +7,7 @@ if [ $# -ne 1 ]; then
 fi
 
 VERSION="$1"
-export PREV_CB_VERSION="v0.0.8"
+export PREV_CB_VERSION="v0.0.9"
 
 javaDefault=11
 javaAccessoryVersions=(8 17)


### PR DESCRIPTION
This PR adds the option to define simple sed-based patches, that can be used to fix broken builds, e.g. to override variables storing constant Scala version value with the version currently tested.