### PR TITLE
Restore verbose missing module mapping info

### DIFF
--- a/project-builder/sbt/CommunityBuildPlugin.scala
+++ b/project-builder/sbt/CommunityBuildPlugin.scala
@@ -287,6 +287,15 @@ object CommunityBuildPlugin extends AutoPlugin {
                 }
             }
             .orElse {
+              println(s"""Module mapping missing:
+                |  id: $id
+                |  testedIds: $testedFullIds
+                |  scalaVersionSuffix: $scalaVersionSuffix
+                |  scalaBinaryVersionSuffix: $scalaBinaryVersionSuffix
+                |  refsByName: ${refsByName.keySet}
+                |  originalModuleIds: ${originalModuleIds.keySet}
+                |  moduleIds: ${moduleIds.keySet}
+                |""".stripMargin)
               idsWithMissingMappings += id
               None
             }


### PR DESCRIPTION
Restore verbose missing module mapping info used for controlling usage sbt builds retries 