### PR TITLE
Use release date to order versions

### DIFF
--- a/coordinator/src/main/scala/Scaladex.scala
+++ b/coordinator/src/main/scala/Scaladex.scala
@@ -3,7 +3,8 @@ import scala.concurrent.*
 
 object Scaladex {
   case class Pagination(current: Int, pageCount: Int, totalSize: Int)
-  case class ArtifactMetadata(version: String)
+  // releaseDate is always UTC zoned
+  case class ArtifactMetadata(version: String, releaseDate: java.time.OffsetDateTime)
   case class ArtifactMetadataResponse(pagination: Pagination, items: List[ArtifactMetadata])
   case class ProjectSummary(
       groupId: String,

--- a/coordinator/src/main/scala/encoding.scala
+++ b/coordinator/src/main/scala/encoding.scala
@@ -1,8 +1,9 @@
 import org.json4s._
 import org.json4s.native.Serialization
 import org.json4s.ext.EnumSerializer
+import java.time.OffsetDateTime
 
-given Formats = Serialization.formats(NoTypeHints) + TestingModeEnumSerializer()
+given Formats = Serialization.formats(NoTypeHints) + TestingModeEnumSerializer() + UTCOffsetDateTimeSerializer()
 
 class TestingModeEnumSerializer
     extends CustomSerializer[TestingMode](format => {
@@ -25,3 +26,16 @@ class TestingModeEnumSerializer
 
 def toJson[T <: AnyRef](obj: T): String = Serialization.write(obj)
 def fromJson[T: Manifest](json: String): T = Serialization.read(json)
+
+
+// Custom serializer in org.json4s.ext does not handle 2022-04-29T03:39:03Z
+class UTCOffsetDateTimeSerializer extends CustomSerializer[OffsetDateTime](format => {
+  def deserialize: PartialFunction[JValue, OffsetDateTime] = {
+    case JString(value)    => OffsetDateTime.parse(value)
+  }
+  def serialize: PartialFunction[Any, JValue] = {
+    case v: OffsetDateTime => JString(v.toString())
+  }
+  (deserialize, serialize)
+  }
+)

--- a/k8s/auth/authz-matrix.yaml
+++ b/k8s/auth/authz-matrix.yaml
@@ -25,6 +25,15 @@ spec:
         permissions: 
           - Overall/Administer
       
+      - name: lampepfl*dotty-core
+        permissions:
+          - Overall/Read
+          - Job/Read
+          - Job/Build
+          - Job/Cancel
+          - Run/Replay
+          - Run/Update
+      
       # Not logged in users
       - name: anonymous
         permissions:


### PR DESCRIPTION
Replaced ordering of versions based on our sem versioning algorithm with simple releaseDate information from Scaladex. It should be more stable, as we get into a cases were sorting finished with an exception due to non transitive order of elements (eg. when trying to build plan for https://index.scala-lang.org/armanbilge/schrodinger)