### PR TITLE
Try to fix problems with updating build plans and generating reports

### DIFF
--- a/.github/actions/build-project/action.yaml
+++ b/.github/actions/build-project/action.yaml
@@ -1,5 +1,5 @@
 name: "Build projects"
-description: "Used to build a project withing the Open cOmunityu Build"
+description: "Used to build a project withing the Open Community Build"
 inputs:
   project-name:
     description: "Name of the project to build"
@@ -161,13 +161,6 @@ runs:
           mv build-logs.txt /opencb/
           mv build-status.txt /opencb/
           mv build-summary.txt /opencb
-
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@v3
-    #   if: steps.check-history.outputs.can-skip-build != 'true'
-    #   with:
-    #     name: ${{ inputs.project-name }}
-    #     path: ${{ github.workspace }}/build-*.txt
 
     - name: Check results
       shell: bash

--- a/.github/workflows/buildAutoUpdatePlan.yaml
+++ b/.github/workflows/buildAutoUpdatePlan.yaml
@@ -41,11 +41,31 @@ jobs:
         # Limit to 1000 most starred project. GitHub actions has problems when rendering workflow of more then 1k jobs
         run: scala-cli run coordinator/ -- 3 -1 1000 "" env/prod/config/replaced-projects.txt env/prod/config/projects-config.conf env/prod/config/filtered-projects.txt
 
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: "buildConfig"
+          path: |
+            .github/workflows/buildPlan.yaml
+            .github/workflows/buildConfig.json
+
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: 303718
+          private_key: ${{ secrets.OPENCB_CONFIG_UPDATE_TOKEN }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
       - name: Create PR
         uses: peter-evans/create-pull-request@v4
         id: cpr
         with:
-          token: ${{ secrets.OPENCB_CONFIG_UPDATE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: Update build config
           assignees: WojciechMazur
           branch: build/scheduled-update

--- a/.github/workflows/buildAutoUpdatePlan.yaml
+++ b/.github/workflows/buildAutoUpdatePlan.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   schedule:
     # Every friday at 4 PM
-    - cron: "0 16 * * 5"
+    - cron: "0 16 1 * *"
   push:
     paths:
       - coordinator/**

--- a/.github/workflows/buildExecuteScheduledWeekly.yaml
+++ b/.github/workflows/buildExecuteScheduledWeekly.yaml
@@ -69,8 +69,8 @@ jobs:
           lastStable=$(./scripts/lastVersionStable.sc)
 
           ./scripts/raport-regressions.scala $scalaVersion > raport-full.md
-          ./scripts/raport-regressions.scala $scalaVersion --compare-with $lastRC > raport-compare-$lastRC.md
-          ./scripts/raport-regressions.scala $scalaVersion --compare-with $lastStable > raport-compare-$lastStable.md
+          ./scripts/raport-regressions.scala $scalaVersion --compareWith=$lastRC > raport-compare-$lastRC.md
+          ./scripts/raport-regressions.scala $scalaVersion --compareWith=$lastStable > raport-compare-$lastStable.md
 
       - name: Upload raports
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
* Fix typos in commands used to generate reports
* Try to generate single use tokens for build plan updates
* Fix typos and commented out code 
* Run build update only once a month