### PR TITLE
Remove lib from filtered-projects after fix tpolecat scala 3 handling

### DIFF
--- a/env/prod/config/filtered-projects.txt
+++ b/env/prod/config/filtered-projects.txt
@@ -34,11 +34,11 @@ neandertech:jsonrpclib:.*
 ## maybe mill issues when mapping
 finos:morphir-scala:.*
 iltotore:iron:.*
-ichoran:kse3:.* 
+ichoran:kse3:.*
 almond-sh:almond:.*
 
 # Not an official release version
-com-lihaoyi:ammonite:.* 
+com-lihaoyi:ammonite:.*
 guardian:support-frontend:.*
 sbt:.*:2.0.0-alpha.*
 
@@ -74,9 +74,8 @@ dmurvihill:courier:.*
 ## Problem with ScalaPB source generation
 jelly-rdf:jelly-jvm:.*
 
-## Uses mill-tpolecat - it does fails to parse RC versions 
+## Uses mill-tpolecat - it does fails to parse RC versions
 joan38:kubernetes-client:.*
-carlosedp:riscvassembler:.*
 neandertech:jsonrpclib:.*
 
 
@@ -120,7 +119,7 @@ scalacenter:scala-debug-adapter:.*
 
 ## Outdated version, needs new release
 2m:yabai-scala:2.0.[0-1]
-caspercommunityio:casper-scala-sdk:1.[0-2].[0-1] 
+caspercommunityio:casper-scala-sdk:1.[0-2].[0-1]
 kevin-lee:maven2sbt:.*
 sciss:serial:.*
 
@@ -131,7 +130,7 @@ jcouyang:meow:0.4.1[0-3]
 es-meta:esmeta:0.[0-1].*
 
 ## 3.2.x
-### Source breaking change 
+### Source breaking change
 # https://github.com/lampepfl/dotty/pull/14840#issuecomment-1182146696
 tinkoff:phobos:0.1[5-6].*
 
@@ -156,7 +155,7 @@ rmgk:slips:.*
 caspercommunityio:casper-scala-sdk:*
 
 # opaque type overrides
-lorandszakacs:sprout:0.0.[0-5]	
+lorandszakacs:sprout:0.0.[0-5]
 
 # Changes to Compiler API
 nrinaudo:kantan.repl:1.*
@@ -168,7 +167,7 @@ pjfanning:jackson-scala3-reflection-extensions:.*
 abdolence:circe-tagged-adt-codec:.*
 errors4s:errors4s-core-circe:.*
 kag0:ninny-json:.*
-nrktkt:ninny-json:.*  
+nrktkt:ninny-json:.*
 karazinscalausersgroup:circe-literal-extras:.*
 jsfwa:zio-cassandra:.*
 sdrafahl:migratepipeline:.*
@@ -188,7 +187,7 @@ zio:zio-aws:.*
 atedeg:mdm:.*
 cognitedata:cognite-sdk-scala:.*
 guymers:ceesvee:.*
-kevin-lee:just-semver:.* 
+kevin-lee:just-semver:.*
 kevin-lee:just-sysprocess:.*
 medeia:medeia:.*
 tharwaninitin:gcp4zio:.*
@@ -199,7 +198,7 @@ xuwei-k:wartremover-scalikejdbc:.*
 ## better2string
 kubukoz:drops:.*
 kubukoz:spotify-next:.*
-kubukoz:sup:.* 
+kubukoz:sup:.*
 polyvariant:colorize-scala:.*
 polyvariant:scodec-java-classfile:.*
 polyvariant:treesitter4s:.*


### PR DESCRIPTION
Remove lib from community build filter after Tpolecat fix from https://github.com/DavidGregory084/mill-tpolecat/pull/18.

This fix is published in the riscvassembler library version 1.7.1.
https://github.com/carlosedp/riscvassembler/releases/tag/v1.7.1