### PR TITLE
Allow for testing more then 1k projects

### DIFF
--- a/.github/workflows/buildAutoUpdatePlan.yaml
+++ b/.github/workflows/buildAutoUpdatePlan.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   schedule:
     # Every friday at 4 PM
-    - cron: "0 16 1 * *"
+    - cron: "0 16 * * 5"
   push:
     paths:
       - coordinator/**
@@ -37,16 +37,17 @@ jobs:
           key: coordinator-data-cache-${{ steps.get-date.outputs.week-start}}
 
       - name: Build plan
-        # Limit to 1000 most starred project. GitHub actions has problems when rendering workflow of more then 1k jobs
-        run: scala-cli run coordinator/ -- 3 -1 1000 "" coordinator/configs
+        # Limit each build plan to at most 1000 most project. 
+        # GitHub actions has problems when rendering workflow of more then 1k jobs
+        # Projects are grouped based on GitHub stars
+        run: scala-cli run coordinator/ -- 3 -1 -1 1000 "" coordinator/configs
 
-      
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: "buildConfig"
           path: |
-            .github/workflows/buildPlan.yaml
+            .github/workflows/buildPlan*.yaml
             .github/workflows/buildConfig.json
 
       - uses: tibdex/github-app-token@v1
@@ -67,5 +68,5 @@ jobs:
           title: "[Bot] Update build config"
           draft: false
           add-paths: |
-            .github/workflows/buildPlan.yaml
+            .github/workflows/buildPlan*.yaml
             .github/workflows/buildConfig.json

--- a/.github/workflows/buildExecuteCustom-A.yaml
+++ b/.github/workflows/buildExecuteCustom-A.yaml
@@ -1,0 +1,91 @@
+name: "Open CB: custom/manual builds A"
+run-name: ${{ inputs.build-name != '' && inputs.build-name || format('Scala {0} @ {1} / {2} {3}{4}', inputs.published-scala-version != '' && inputs.published-scala-version || 'snapshot', inputs.repository-url, inputs.repository-branch, inputs.extra-scalac-options != '' && format('extraScalacOptions={0} ', inputs.extra-scalac-options) || '', inputs.disabled-scalac-options != '' && format('disabledScalacOptions={0}', inputs.disabled-scalac-options) || '' ) }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-name:
+        type: string
+        description: "Custom name of the job in GitHub Actions"
+        default: ""
+      published-scala-version:
+        type: string
+        description: "Published Scala version to use, if empty new version of compiler would be build with default name based on the selected repository"
+      repository-url:
+        type: string
+        description: "GitHub repository URL for compiler to build, ignored when published-scala-version is defined"
+        default: "lampepfl/dotty"
+      repository-branch:
+        type: string
+        description: "GitHub repository branch for compiler to build, ignored when published-scala-version is defined"
+        default: "main"
+      extra-scalac-options:
+        type: string
+        description: "List of scalacOptions which should be used when building projects. Multiple entires should be seperated by a single comma character `,`"
+        default: ""
+      disabled-scalac-options:
+        type: string
+        description: "List of scalacOptions which should be filtered out when building projects."
+        default: ""
+      push-to-gh-pages:
+        type: boolean
+        description: "Should the workflow push the generated raport to gh-pages branch"
+        default: false
+jobs:
+  # Name of this job need to match inputs of build-project/job-info
+  execute-build-plan:
+    uses: ./.github/workflows/buildPlan-A.yaml
+    with:
+      published-scala-version: ${{ inputs.published-scala-version }}
+      repository-url: ${{ inputs.repository-url }}
+      repository-branch: ${{ inputs.repository-branch }}
+      extra-scalac-options: ${{ inputs.extra-scalac-options }}
+      disabled-scalac-options: ${{ inputs.disabled-scalac-options }}
+    secrets: inherit
+
+  create-raport:
+    needs: [execute-build-plan]
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Install coursier
+        uses: coursier/setup-action@v1
+        with:
+          apps: scala-cli
+
+      - name: Generate raport
+        env:
+          ES_USER: ${{ secrets.OPENCB_ELASTIC_USER }}
+          ES_PASSWORD: ${{ secrets.OPENCB_ELASTIC_PSWD }}
+        run: |
+          scalaVersion=${{ needs.execute-build-plan.outputs.used-scala-version }}
+          lastRC="$(./scripts/lastVersionRC.sc)"
+          lastStable=$(./scripts/lastVersionStable.sc)
+
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion > raport-full.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastRC > raport-compare-$lastRC.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastStable > raport-compare-$lastStable.md
+
+      - name: Upload raports
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-raports
+          path: ${{ github.workspace }}/raport-*.md
+
+      - uses: tibdex/github-app-token@v1
+        if: ${{ inputs.push-to-gh-pages }}
+        id: generate-token
+        with:
+          app_id: 303718
+          private_key: ${{ secrets.OPENCB_CONFIG_UPDATE_TOKEN }}
+
+      - name: Push raport
+        if: ${{ inputs.push-to-gh-pages }}
+        uses: ./.github/actions/push-raport-to-gh-pages
+        with:
+          artifact-name: build-raports
+          file-to-pick: raport-full.md
+          build-title: ${{ needs.execute-build-plan.outputs.used-scala-version }}
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/buildExecuteCustom-B.yaml
+++ b/.github/workflows/buildExecuteCustom-B.yaml
@@ -1,0 +1,91 @@
+name: "Open CB: custom/manual builds B"
+run-name: ${{ inputs.build-name != '' && inputs.build-name || format('Scala {0} @ {1} / {2} {3}{4}', inputs.published-scala-version != '' && inputs.published-scala-version || 'snapshot', inputs.repository-url, inputs.repository-branch, inputs.extra-scalac-options != '' && format('extraScalacOptions={0} ', inputs.extra-scalac-options) || '', inputs.disabled-scalac-options != '' && format('disabledScalacOptions={0}', inputs.disabled-scalac-options) || '' ) }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-name:
+        type: string
+        description: "Custom name of the job in GitHub Actions"
+        default: ""
+      published-scala-version:
+        type: string
+        description: "Published Scala version to use, if empty new version of compiler would be build with default name based on the selected repository"
+      repository-url:
+        type: string
+        description: "GitHub repository URL for compiler to build, ignored when published-scala-version is defined"
+        default: "lampepfl/dotty"
+      repository-branch:
+        type: string
+        description: "GitHub repository branch for compiler to build, ignored when published-scala-version is defined"
+        default: "main"
+      extra-scalac-options:
+        type: string
+        description: "List of scalacOptions which should be used when building projects. Multiple entires should be seperated by a single comma character `,`"
+        default: ""
+      disabled-scalac-options:
+        type: string
+        description: "List of scalacOptions which should be filtered out when building projects."
+        default: ""
+      push-to-gh-pages:
+        type: boolean
+        description: "Should the workflow push the generated raport to gh-pages branch"
+        default: false
+jobs:
+  # Name of this job need to match inputs of build-project/job-info
+  execute-build-plan:
+    uses: ./.github/workflows/buildPlan-B.yaml
+    with:
+      published-scala-version: ${{ inputs.published-scala-version }}
+      repository-url: ${{ inputs.repository-url }}
+      repository-branch: ${{ inputs.repository-branch }}
+      extra-scalac-options: ${{ inputs.extra-scalac-options }}
+      disabled-scalac-options: ${{ inputs.disabled-scalac-options }}
+    secrets: inherit
+
+  create-raport:
+    needs: [execute-build-plan]
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Install coursier
+        uses: coursier/setup-action@v1
+        with:
+          apps: scala-cli
+
+      - name: Generate raport
+        env:
+          ES_USER: ${{ secrets.OPENCB_ELASTIC_USER }}
+          ES_PASSWORD: ${{ secrets.OPENCB_ELASTIC_PSWD }}
+        run: |
+          scalaVersion=${{ needs.execute-build-plan.outputs.used-scala-version }}
+          lastRC="$(./scripts/lastVersionRC.sc)"
+          lastStable=$(./scripts/lastVersionStable.sc)
+
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion > raport-full.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastRC > raport-compare-$lastRC.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastStable > raport-compare-$lastStable.md
+
+      - name: Upload raports
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-raports
+          path: ${{ github.workspace }}/raport-*.md
+
+      - uses: tibdex/github-app-token@v1
+        if: ${{ inputs.push-to-gh-pages }}
+        id: generate-token
+        with:
+          app_id: 303718
+          private_key: ${{ secrets.OPENCB_CONFIG_UPDATE_TOKEN }}
+
+      - name: Push raport
+        if: ${{ inputs.push-to-gh-pages }}
+        uses: ./.github/actions/push-raport-to-gh-pages
+        with:
+          artifact-name: build-raports
+          file-to-pick: raport-full.md
+          build-title: ${{ needs.execute-build-plan.outputs.used-scala-version }}
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/buildExecuteScheduledWeekly-A.yaml
+++ b/.github/workflows/buildExecuteScheduledWeekly-A.yaml
@@ -1,0 +1,109 @@
+name: "Open CB: scheduled weekly A"
+run-name: "Weekly build A #${{ github.run_number }}"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every friday at 8 PM
+    - cron: "0 20 * * 5"
+jobs:
+  detect-version:
+    runs-on: ubuntu-22.04
+    continue-on-error: false
+    outputs:
+      last-nightly-version: ${{ steps.detect.outputs.last-nightly-version }}
+      last-stable-version: ${{ steps.detect.outputs.last-stable-version }}
+      last-rc-version: ${{ steps.detect.outputs.last-rc-version }}
+    if: github.event_name == 'schedule' && github.repository == 'VirtusLab/community-build3' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
+      - name: Install scala-cli
+        uses: coursier/setup-action@v1
+        with:
+          apps: scala-cli
+
+      - name: Find last versions
+        id: detect
+        run: |
+          lastNightly="$(./scripts/lastVersionNightly.sc)"
+          lastStable="$(./scripts/lastVersionStable.sc)"
+          lastRC="$(./scripts/lastVersionRC.sc)" 
+
+          echo "Detected last nightly version: $lastNightly (used)"
+          echo "Detected last stable version:  $lastStable"
+          echo "Detected last RC version:      $lastRC"
+
+          echo "last-nightly-version=$lastNightly" >> $GITHUB_OUTPUT
+          echo "last-stable-version=$lastStable" >> $GITHUB_OUTPUT
+          echo "last-rc-version=$lastRC" >> $GITHUB_OUTPUT
+
+  # Name of this job need to match inputs of build-project/job-info
+  execute-build-plan:
+    needs: [detect-version]
+    uses: ./.github/workflows/buildPlan-A.yaml
+    with:
+      published-scala-version: ${{ needs.detect-version.outputs.last-nightly-version }}
+    secrets: inherit
+
+  create-raport:
+    needs: [execute-build-plan]
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Install coursier
+        uses: coursier/setup-action@v1
+        with:
+          apps: scala-cli
+
+      - name: Cache last successfull version
+        uses: actions/cache@v3
+        with:
+          path: ./last-successfull-weekly-version
+          key: last-successfull-weekly-version
+
+      - name: Generate raport
+        env:
+          ES_USER: ${{ secrets.OPENCB_ELASTIC_USER }}
+          ES_PASSWORD: ${{ secrets.OPENCB_ELASTIC_PSWD }}
+        run: |
+          scalaVersion=${{ needs.execute-build-plan.outputs.used-scala-version }}
+          lastRC="$(./scripts/lastVersionRC.sc)"
+          lastStable=$(./scripts/lastVersionStable.sc)
+
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion > raport-full.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastRC > raport-compare-$lastRC.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastStable > raport-compare-$lastStable.md
+
+          lastWeeklyVersionFile=./last-successfull-weekly-version
+          if [[ -f "$lastWeeklyVersionFile" ]]; then
+            lastWeeklyVersion=$(cat $lastWeeklyVersionFile)
+            echo "Comparing with last foundly weekly version: ${lastWeeklyVersion}"
+            scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastWeeklyVersion > raport-compare-$lastWeeklyVersion.md
+          else 
+            echo "Not found previous weekly build version."
+          fi
+          echo "$scalaVersion" > $lastWeeklyVersionFile
+
+      - name: Upload raports
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-raports
+          path: ${{ github.workspace }}/raport-*.md
+
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: 303718
+          private_key: ${{ secrets.OPENCB_CONFIG_UPDATE_TOKEN }}
+
+      - name: Push raport
+        uses: ./.github/actions/push-raport-to-gh-pages
+        with:
+          artifact-name: build-raports
+          file-to-pick: raport-full.md
+          build-title: ${{ needs.execute-build-plan.outputs.used-scala-version }}
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/buildExecuteScheduledWeekly-B.yaml
+++ b/.github/workflows/buildExecuteScheduledWeekly-B.yaml
@@ -1,0 +1,109 @@
+name: "Open CB: scheduled weekly B"
+run-name: "Weekly build B #${{ github.run_number }}"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every friday at 8 PM
+    - cron: "0 20 * * 5"
+jobs:
+  detect-version:
+    runs-on: ubuntu-22.04
+    continue-on-error: false
+    outputs:
+      last-nightly-version: ${{ steps.detect.outputs.last-nightly-version }}
+      last-stable-version: ${{ steps.detect.outputs.last-stable-version }}
+      last-rc-version: ${{ steps.detect.outputs.last-rc-version }}
+    if: github.event_name == 'schedule' && github.repository == 'VirtusLab/community-build3' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
+      - name: Install scala-cli
+        uses: coursier/setup-action@v1
+        with:
+          apps: scala-cli
+
+      - name: Find last versions
+        id: detect
+        run: |
+          lastNightly="$(./scripts/lastVersionNightly.sc)"
+          lastStable="$(./scripts/lastVersionStable.sc)"
+          lastRC="$(./scripts/lastVersionRC.sc)" 
+
+          echo "Detected last nightly version: $lastNightly (used)"
+          echo "Detected last stable version:  $lastStable"
+          echo "Detected last RC version:      $lastRC"
+
+          echo "last-nightly-version=$lastNightly" >> $GITHUB_OUTPUT
+          echo "last-stable-version=$lastStable" >> $GITHUB_OUTPUT
+          echo "last-rc-version=$lastRC" >> $GITHUB_OUTPUT
+
+  # Name of this job need to match inputs of build-project/job-info
+  execute-build-plan:
+    needs: [detect-version]
+    uses: ./.github/workflows/buildPlan-B.yaml
+    with:
+      published-scala-version: ${{ needs.detect-version.outputs.last-nightly-version }}
+    secrets: inherit
+
+  create-raport:
+    needs: [execute-build-plan]
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Install coursier
+        uses: coursier/setup-action@v1
+        with:
+          apps: scala-cli
+
+      - name: Cache last successfull version
+        uses: actions/cache@v3
+        with:
+          path: ./last-successfull-weekly-version
+          key: last-successfull-weekly-version
+
+      - name: Generate raport
+        env:
+          ES_USER: ${{ secrets.OPENCB_ELASTIC_USER }}
+          ES_PASSWORD: ${{ secrets.OPENCB_ELASTIC_PSWD }}
+        run: |
+          scalaVersion=${{ needs.execute-build-plan.outputs.used-scala-version }}
+          lastRC="$(./scripts/lastVersionRC.sc)"
+          lastStable=$(./scripts/lastVersionStable.sc)
+
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion > raport-full.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastRC > raport-compare-$lastRC.md
+          scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastStable > raport-compare-$lastStable.md
+
+          lastWeeklyVersionFile=./last-successfull-weekly-version
+          if [[ -f "$lastWeeklyVersionFile" ]]; then
+            lastWeeklyVersion=$(cat $lastWeeklyVersionFile)
+            echo "Comparing with last foundly weekly version: ${lastWeeklyVersion}"
+            scala-cli scripts/raport-regressions.scala scripts/md_printer.scala -- $scalaVersion --compareWith=$lastWeeklyVersion > raport-compare-$lastWeeklyVersion.md
+          else 
+            echo "Not found previous weekly build version."
+          fi
+          echo "$scalaVersion" > $lastWeeklyVersionFile
+
+      - name: Upload raports
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-raports
+          path: ${{ github.workspace }}/raport-*.md
+
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: 303718
+          private_key: ${{ secrets.OPENCB_CONFIG_UPDATE_TOKEN }}
+
+      - name: Push raport
+        uses: ./.github/actions/push-raport-to-gh-pages
+        with:
+          artifact-name: build-raports
+          file-to-pick: raport-full.md
+          build-title: ${{ needs.execute-build-plan.outputs.used-scala-version }}
+          token: ${{ steps.generate-token.outputs.token }}

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -234,7 +234,7 @@ object BuildInfo:
         /* scalaBinaryVersion = */ 3,
         /* minStartsCount = */ 0,
         /* maxProjectsInConfig = */ 0,
-        /* maxProjectsInBuildPlan = */ 0,
+        /* maxProjectsInBuildPlan = */ -1,
         /* requiredProjects = */ config.customRun.projectName,
         /* configsPath = */ communityBuildDir / "coordinator" / "configs"
       )

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -233,7 +233,8 @@ object BuildInfo:
       val args = Seq[os.Shellable](
         /* scalaBinaryVersion = */ 3,
         /* minStartsCount = */ 0,
-        /* maxProjectsCount = */ 0,
+        /* maxProjectsInConfig = */ 0,
+        /* maxProjectsInBuildPlan = */ 0,
         /* requiredProjects = */ config.customRun.projectName,
         /* configsPath = */ communityBuildDir / "coordinator" / "configs"
       )

--- a/coordinator/src/main/scala/buildPlan.scala
+++ b/coordinator/src/main/scala/buildPlan.scala
@@ -65,7 +65,7 @@ val ForReproducer = sys.props.contains("opencb.coordinator.reproducer-mode")
       println("CI build config saved")
     }
     // Build plan
-    val buildPlanProjectsLimit = Option(maxProjectsInBuildPlan).filter(_ >= 0)
+    val buildPlanProjectsLimit = Option(maxProjectsInBuildPlan).filter(_ >= 1)
     buildPlanProjectsLimit
       .fold(SplittedBuildPlan(fullBuildPlan) :: Nil)(
         splitBuildPlan(fullBuildPlan, _)


### PR DESCRIPTION
Splits community build into multiuple build plans: A,B (in the future C, D ...), each having N=1000 projects. Splitting the build into smaller entities starts to be necessary, as we've reached over 1.4k Scala 3 projects (after applying filters).  
Each build plan needs to be started seperately, becouse our main limitation is GitHub Actions UI, which is frequently failing to load becouse of too many projects. 

The previous workflows for single buildPlan would be removed in the future, after testing new approach.