### PR TITLE
Allow to define custom project prepare scripts

### DIFF
--- a/.github/actions/build-project/action.yaml
+++ b/.github/actions/build-project/action.yaml
@@ -94,15 +94,21 @@ runs:
     - name: Prepare SSH keys
       shell: bash
       run: |
-        echo "${{ inputs.github-key }}" > ${{ github.workspace }}/github_rsa
+        echo "${{ inputs.github-key }}" > ${{ github.workspace }}/github_key
 
     - name: Build project
       uses: addnab/docker-run-action@v3
       if: steps.check-history.outputs.can-skip-build != 'true'
       with:
         image: "virtuslab/scala-community-build-project-builder:jdk${{ env.java-version }}-v0.2.7"
-        options: -v ${{ github.workspace }}:/opencb/ -v ${{ github.workspace }}/github_rsa:/root/.ssh/id_rsa:ro
+        options: -v ${{ github.workspace }}:/opencb/ -v ${{ github.workspace }}/github_key:/root/.ssh/github_key:ro
         run: |
+          # Setup ssh required for downloading submodules
+          eval "$(ssh-agent -s)"
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-add ~/.ssh/github_key
+
           DefaultConfig='{}'
           ConfigFile="/opencb/.github/workflows/buildConfig.json"
           config () { 

--- a/.github/actions/build-project/action.yaml
+++ b/.github/actions/build-project/action.yaml
@@ -100,7 +100,7 @@ runs:
       uses: addnab/docker-run-action@v3
       if: steps.check-history.outputs.can-skip-build != 'true'
       with:
-        image: "virtuslab/scala-community-build-project-builder:jdk${{ env.java-version }}-v0.2.6"
+        image: "virtuslab/scala-community-build-project-builder:jdk${{ env.java-version }}-v0.2.7"
         options: -v ${{ github.workspace }}:/opencb/ -v ${{ github.workspace }}/github_rsa:/root/.ssh/id_rsa:ro
         run: |
           DefaultConfig='{}'

--- a/.github/actions/build-project/action.yaml
+++ b/.github/actions/build-project/action.yaml
@@ -115,6 +115,7 @@ runs:
           echo 'failure' > build-status.txt 
 
           /build/build-revision.sh \
+            "$(config .project)" \
             "$(config .repoUrl)" \
             "$(config .revision)" \
             "${{ inputs.scala-version }}" \

--- a/.github/actions/setup-build/action.yaml
+++ b/.github/actions/setup-build/action.yaml
@@ -73,7 +73,7 @@ runs:
       uses: addnab/docker-run-action@v3
       if: steps.check-published.outputs.is-compiler-published == 'false'
       with:
-        image: "virtuslab/scala-community-build-compiler-builder:v0.2.6"
+        image: "virtuslab/scala-community-build-compiler-builder:v0.2.7"
         options: -v ${{ github.workspace }}/compiler:/compiler/
         run: |
           Version="${{ steps.calc-version.outputs.effective-scala-version }}"

--- a/cli/scb-cli.scala
+++ b/cli/scb-cli.scala
@@ -31,7 +31,7 @@ class FailedProjectException(msg: String)
     with NoStackTrace
 
 val communityBuildVersion =
-  sys.props.getOrElse("communitybuild.version", "v0.2.6")
+  sys.props.getOrElse("communitybuild.version", "v0.2.7")
 private val CBRepoName = "VirtusLab/community-build3"
 val projectBuilderUrl =
   s"https://raw.githubusercontent.com/$CBRepoName/master/project-builder"

--- a/coordinator/configs/projects-config.conf
+++ b/coordinator/configs/projects-config.conf
@@ -1,6 +1,15 @@
 # Content of this file is expected to be moved into actual projects in the future
 47degrees_sbt-energymonitor.tests=compile-only
-7mind_izumi.tests=compile-only
+7mind_izumi {
+  tests=compile-only
+  source-patches = [
+   { 
+    path = "project/Deps.sc"
+    pattern      = "val scala300 = ScalaVersion\\((.*)\\)"
+    replace-with = "val scala300 = ScalaVersion(\"<SCALA_VERSION>\")"
+   }
+  ]
+}
 
 aaronp_code-template.tests=compile-only # uses sript engine factory to work with repl, breaks in RC releases 
 absaoss_absa-shaded-jackson-module-scala.tests = disabled # Does not compile in any version

--- a/k8s/project-builder-mill-test.yaml
+++ b/k8s/project-builder-mill-test.yaml
@@ -14,6 +14,7 @@ spec:
         - "-c"
         - |
             (/build/build-revision.sh \
+              "com-lihaoyi/upickle" \
               https://github.com/com-lihaoyi/upickle.git \
               1.5.0 \
               3.1.0 \

--- a/k8s/project-builder-sbt-test.yaml
+++ b/k8s/project-builder-sbt-test.yaml
@@ -17,6 +17,7 @@ spec:
             - "-c"
             - |
               (/build/build-revision.sh \
+                typelevel/shapeless-3 \
                 https://github.com/typelevel/shapeless-3.git \
                 "v3.3.0" \
                 3.2.2 \

--- a/project-builder/build-revision.sh
+++ b/project-builder/build-revision.sh
@@ -1,47 +1,36 @@
 #!/usr/bin/env bash
 set -e
 
-if [ $# -ne 10 ]; then
+if [ $# -ne 11 ]; then
   echo "Wrong number of script arguments"
   exit 1
 fi
 
-repoUrl="$1"            # e.g. 'https://github.com/Stiuil06/deploySbt.git'
-rev="$2"                # e.g. '1.0.2'
-scalaVersion="$3"       # e.g. 3.0.0-RC3
-version="$4"            # e.g. '1.0.2-communityBuild'
-targets="$5"            # e.g. com.example%greeter
-mvnRepoUrl="$6"         # e.g. https://mvn-repo/maven2/2021-05-23_1
-enforcedSbtVersion="$7" # e.g. '1.5.5' or empty ''
-projectConfig="$8"
-extraScalacOptions="$9" # e.g '' or "-Wunused:all -Ylightweight-lazy-vals"
-disabledScalacOption="${10}"
+project="$1"
+repoUrl="$2"            # e.g. 'https://github.com/Stiuil06/deploySbt.git'
+rev="$3"                # e.g. '1.0.2'
+scalaVersion="$4"       # e.g. 3.0.0-RC3
+version="$5"            # e.g. '1.0.2-communityBuild'
+targets="$6"            # e.g. com.example%greeter
+mvnRepoUrl="$7"         # e.g. https://mvn-repo/maven2/2021-05-23_1
+enforcedSbtVersion="$8" # e.g. '1.5.5' or empty ''
+projectConfig="$9"
+extraScalacOptions="${10}" # e.g '' or "-Wunused:all -Ylightweight-lazy-vals"
+disabledScalacOption="${11}"
 
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+export OPENCB_SCRIPT_DIR=$scriptDir
 
 $scriptDir/checkout.sh "$repoUrl" "$rev" repo
 
-# Wait until mvn-repo is reachable, frequently few first requests might fail
-# especially in cli immediately after starting minikube
-for i in {1..10}; do
-  if errMsg=$(curl $mvnRepoUrl 2>&1); then
-    echo "Connected with $mvnRepoUrl."
-    break
-  else
-    echo "${errMsg}"
-    echo "Waiting until mvn-repo is reachable..."
-    sleep 1
-  fi
-done
-
 if [ -f "repo/mill" ] || [ -f "repo/build.sc" ]; then
   echo "Mill project found: ${isMillProject}"
-  $scriptDir/mill/prepare-project.sh repo "$scalaVersion" "$version" "$projectConfig"
+  $scriptDir/mill/prepare-project.sh "$project" repo "$scalaVersion" "$version" "$projectConfig"
   $scriptDir/mill/build.sh repo "$scalaVersion" "$version" "$targets" "$mvnRepoUrl" "$projectConfig" "$extraScalacOptions" "$disabledScalacOption"
 
 elif [ -f "repo/build.sbt" ]; then
   echo "sbt project found: ${isSbtProject}"
-  $scriptDir/sbt/prepare-project.sh repo "$enforcedSbtVersion" "$scalaVersion" "$projectConfig"
+  $scriptDir/sbt/prepare-project.sh "$project" repo "$enforcedSbtVersion" "$scalaVersion" "$projectConfig"
   $scriptDir/sbt/build.sh repo "$scalaVersion" "$version" "$targets" "$mvnRepoUrl" "$projectConfig" "$extraScalacOptions" "$disabledScalacOption"
 else
   echo "Not found sbt or mill build files, assuming scala-cli project"

--- a/project-builder/checkout.sh
+++ b/project-builder/checkout.sh
@@ -19,5 +19,5 @@ branch=""
 if [ -n "$rev" ]; then
   branch="-b $rev"
 fi
-git clone --quiet "$repo" "$repoDir" $branch || 
-  ( git clone --quiet "$repo" "$repoDir" && cd $repoDir && git checkout $rev )
+git clone --quiet --recurse-submodules "$repo" "$repoDir" $branch || 
+  ( git clone --quiet --recurse-submodules "$repo" "$repoDir" && cd $repoDir && git checkout $rev )

--- a/project-builder/prepare-scripts/7mind/izumi.sh
+++ b/project-builder/prepare-scripts/7mind/izumi.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ProjectDir="${OPENCB_PROJECT_DIR:?OPENCB_PROJECT_DIR is not defined}"
+cd $ProjectDir
+if which cs >/dev/null 2>&1; then
+  ./sbtgen.sc
+else
+  echo "Not found coursier, trying to install"
+  curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > ./cs
+  chmod +x ./cs
+  PATH=$PATH:$PWD ./sbtgen.sc
+fi

--- a/scripts/bisect.scala
+++ b/scripts/bisect.scala
@@ -9,7 +9,7 @@ import java.nio.file.attribute.PosixFilePermissions
 import java.nio.charset.StandardCharsets
 import java.nio.file._
 
-val communityBuildVersion = "v0.2.6"
+val communityBuildVersion = "v0.2.7"
 
 @main def run(args: String*): Unit =
   val config = scopt.OParser

--- a/scripts/bisect.scala
+++ b/scripts/bisect.scala
@@ -178,6 +178,7 @@ object ValidationScript:
     |echo 'failure' > build-status.txt
     |
     |/build/build-revision.sh \
+    |  "$$(config .project)" \
     |  "$$(config .repoUrl)" \
     |  "$revision" \
     |  "$${scalaVersion}" \

--- a/scripts/raport-regressions.scala
+++ b/scripts/raport-regressions.scala
@@ -110,9 +110,6 @@ lazy val PreviousScalaReleases = (StableScalaVersions ++ NightlyReleases).sorted
   compareWithScalaVersion.foreach(v => log("Comparing Wtih Scala version: " + v))
 
   printLine()
-  println(
-    s"Reporting failed community build projects using Scala $scalaVersion:$LINE_BREAK\n"
-  )
   val failedProjects = listFailedProjects(scalaVersion, checkBuildId)
   printLine()
 


### PR DESCRIPTION
Adds ability to define custom scripts in `project-builder/prepeare-scripts/<org>/<repo>.sh` which would be evaluated after source patches and before start of the build. This is going to fix issues with `7mind/izumi` projects which use autogenerate, hard to adapt `build.sbt` config. 

Other changes: 
* Uprade version to v0.2.7
* Fix issues with checking out submodules (scacenter/scala-debug-adapter)