### PR TITLE
Share logic between sbt and mill for setting scalacOptions

### DIFF
--- a/project-builder/build-revision.sh
+++ b/project-builder/build-revision.sh
@@ -24,6 +24,25 @@ export OPENCB_SCRIPT_DIR=$scriptDir
 $scriptDir/checkout.sh "$repoUrl" "$rev" repo
 buildToolFile="build-tool.txt"
 
+scalaBinaryVersion=`echo $scalaVersion | cut -d . -f 1,2`
+scalaBinaryVersionMajor=`echo $scalaVersion | cut -d . -f 1`
+scalaBinaryVersionMinor=`echo $scalaVersion | cut -d . -f 2`
+echo "Scala binary version found: $scalaBinaryVersion"
+
+commonAppendScalacOptions="-source:$scalaBinaryVersion-migration,-Wconf:msg=can be rewritten automatically under -rewrite -source $scalaBinaryVersion-migration:s"
+commonRemoveScalacOptions="-deprecation,-feature,-Xfatal-warnings,-Werror,MATCH:.*-Wconf.*any:e,-migration,"
+echo "Would try to apply common scalacOption (best-effort, sbt/mill only):"
+echo "Append: $commonAppendScalacOptions"
+echo "Remove: $commonRemoveScalacOptions"
+
+if [ -z $extraScalacOptions ];then extraScalacOptions="$commonAppendScalacOptions"
+else  extraScalacOptions="$extraScalacOptions,$commonAppendScalacOptions"
+fi
+
+if [ -z $disabledScalacOption ];then disabledScalacOption="$commonRemoveScalacOptions"
+else disabledScalacOption="$disabledScalacOption,$commonRemoveScalacOptions"; 
+fi
+
 if [ -f "repo/mill" ] || [ -f "repo/build.sc" ]; then
   echo "Mill project found: ${isMillProject}"
   echo "mill" > $buildToolFile

--- a/project-builder/build-revision.sh
+++ b/project-builder/build-revision.sh
@@ -27,8 +27,8 @@ buildToolFile="build-tool.txt"
 if [ -f "repo/mill" ] || [ -f "repo/build.sc" ]; then
   echo "Mill project found: ${isMillProject}"
   echo "mill" > $buildToolFile
-  $scriptDir/mill/prepare-project.sh "$project" repo "$scalaVersion" "$version" "$projectConfig" "$extraScalacOptions" "$disabledScalacOption"
-  $scriptDir/mill/build.sh repo "$scalaVersion" "$version" "$targets" "$mvnRepoUrl" "$projectConfig"
+  $scriptDir/mill/prepare-project.sh "$project" repo "$scalaVersion" "$version" "$projectConfig" 
+  $scriptDir/mill/build.sh repo "$scalaVersion" "$version" "$targets" "$mvnRepoUrl" "$projectConfig" "$extraScalacOptions" "$disabledScalacOption"
 
 elif [ -f "repo/build.sbt" ]; then
   echo "sbt project found: ${isSbtProject}"

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -126,25 +126,14 @@ private object ScalacOptionsSettings {
       .getOrElse(Nil)
   val append = parse("communitybuild.appendScalacOptions")
   val remove = parse("communitybuild.removeScalacOptions")
-  val filters = (append ++ remove).distinct.map { setting =>
-    Seq[String => String](
-      setting => if (setting.startsWith("--")) setting.tail else setting,
-      setting => {
-        setting.indexOf(':') match {
-          case -1 => setting
-          case n  => setting.substring(0, n + 1) //
-        }
-      }
-    ).reduce(_.andThen(_))
-      .apply(setting)
-  }
 }
 
-def mapScalacOptions(current: Seq[String]): Seq[String] = {
-  current
-    .filterNot(s => ScalacOptionsSettings.filters.exists(_.contains(s)))
-    .appendedAll(ScalacOptionsSettings.append)
-}
+def mapScalacOptions(current: Seq[String]): Seq[String] =
+  CommunityBuildCore.Scala3CommunityBuild.Utils.mapScalacOptions(
+    current = current,
+    append = ScalacOptionsSettings.append,
+    remove = ScalacOptionsSettings.remove
+  )
 
 case class ModuleInfo(org: String, name: String, module: Module) {
   val targetName = s"$org%$name"

--- a/project-builder/mill/build.sh
+++ b/project-builder/mill/build.sh
@@ -25,6 +25,8 @@ echo Disting version $version for ${#targets[@]} targets: ${targets[@]}
 echo Project projectConfig: $projectConfig
 echo '##################################'
 
+scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 cd $repoDir
 
 millSettings=(
@@ -46,6 +48,6 @@ function tryBuild() {
 }
 
 
-# Retry only if previous build failed to start
-export MILL_VERSION=$millVersion
-tryBuild mill || ([[ -f ./mill && ! -s ../build-summary.txt ]] && tryBuild ./mill)
+if [[ -f .mill ]]; then tryBuild .mill
+else tryBuild "${scriptDir}/millw --mill-version $(cat .mill-version)"
+fi

--- a/project-builder/mill/build.sh
+++ b/project-builder/mill/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-if [ $# -ne 6 ]; then
-  echo "Wrong number of script arguments, expected $0 <repo_dir> <scala-version> <version> <targets> <maven_repo> <sbt_version?> <project_config?>, got $#: $@"
+if [ $# -ne 8 ]; then
+  echo "Wrong number of script arguments, expected $0 <repo_dir> <scala-version> <version> <targets> <maven_repo> <sbt_version?> <project_config?> <extra-scalacOption?> <disabled-scalacOptions?>, got $#: $@"
   exit 1
 fi
 
@@ -12,6 +12,8 @@ version="$3"      # e.g. 1.0.2-communityBuild
 targets=($4)      # e.g. "com.example%foo com.example%bar"
 mavenRepoUrl="$5" # e.g. https://mvn-repo/maven2/2021-05-23_1
 projectConfig="$6"
+extraScalacOptions="$7"
+disabledScalacOption="$8"
 
 if [[ -z $projectConfig ]]; then
   projectConfig="{}"
@@ -32,6 +34,8 @@ millSettings=(
   -D communitybuild.version="$version"
   -D communitybuild.maven.url="$mavenRepoUrl"
   -D communitybuild.scala="$scalaVersion"
+  -D communitybuild.appendScalacOptions="$extraScalacOptions"
+  -D communitybuild.removeScalacOptions="-deprecation,-feature,-Xfatal-warnings,-Werror,$disabledScalacOption"
   $(echo $projectConfig | jq -r '.mill?.options? // [] | join(" ")' | sed "s/<SCALA_VERSION>/${scalaVersion}/g")
 )
 

--- a/project-builder/mill/compat/0.9.sc
+++ b/project-builder/mill/compat/0.9.sc
@@ -1,0 +1,15 @@
+object compat {
+  type CoursierModule = mill.scalalib.CoursierModule
+  type JavaModule = mill.scalalib.JavaModule
+  type PublishModule = mill.scalalib.PublishModule
+  type ScalaModule = mill.scalalib.ScalaModule
+  type TestModule = mill.scalalib.TestModule
+  type ZincWorkerModule = mill.scalalib.ZincWorkerModule
+  type TestResult = mill.scalalib.TestRunner.Result
+  object Val {
+    def unapply(v: Any) = Some(v)
+  }
+  type Task[+T] = mill.define.Task[T]
+
+  def toZincWorker(v: ZincWorkerModule) = v
+}

--- a/project-builder/mill/millw
+++ b/project-builder/mill/millw
@@ -1,0 +1,241 @@
+#!/usr/bin/env sh
+
+# This is a wrapper script, that automatically download mill from GitHub release pages
+# You can give the required mill version with --mill-version parameter
+# If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+#
+# Project page: https://github.com/lefou/millw
+# Script Version: 0.4.11
+#
+# If you want to improve this script, please also contribute your changes back!
+#
+# Licensed under the Apache License, Version 2.0
+
+set -e
+
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
+  DEFAULT_MILL_VERSION="0.11.4"
+fi
+
+
+if [ -z "${GITHUB_RELEASE_CDN}" ] ; then
+  GITHUB_RELEASE_CDN=""
+fi
+
+
+MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
+
+if [ -z "${CURL_CMD}" ] ; then
+  CURL_CMD=curl
+fi
+
+# Explicit commandline argument takes precedence over all other methods
+if [ "$1" = "--mill-version" ] ; then
+  shift
+  if [ "x$1" != "x" ] ; then
+    MILL_VERSION="$1"
+    shift
+  else
+    echo "You specified --mill-version without a version." 1>&2
+    echo "Please provide a version that matches one provided on" 1>&2
+    echo "${MILL_REPO_URL}/releases" 1>&2
+    false
+  fi
+fi
+
+# Please note, that if a MILL_VERSION is already set in the environment,
+# We reuse it's value and skip searching for a value.
+
+# If not already set, read .mill-version file
+if [ -z "${MILL_VERSION}" ] ; then
+  if [ -f ".mill-version" ] ; then
+    MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
+  elif [ -f ".config/mill-version" ] ; then
+    MILL_VERSION="$(head -n 1 .config/mill-version 2> /dev/null)"
+  fi
+fi
+
+MILL_USER_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/mill"
+
+if [ -z "${MILL_DOWNLOAD_PATH}" ] ; then
+  MILL_DOWNLOAD_PATH="${MILL_USER_CACHE_DIR}/download"
+fi
+
+# If not already set, try to fetch newest from Github
+if [ -z "${MILL_VERSION}" ] ; then
+  # TODO: try to load latest version from release page
+  echo "No mill version specified." 1>&2
+  echo "You should provide a version via '.mill-version' file or --mill-version option." 1>&2
+
+  mkdir -p "${MILL_DOWNLOAD_PATH}"
+  LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest" 2>/dev/null || (
+    # we might be on OSX or BSD which don't have -d option for touch
+    # but probably a -A [-][[hh]mm]SS
+    touch "${MILL_DOWNLOAD_PATH}/.expire_latest"; touch -A -010000 "${MILL_DOWNLOAD_PATH}/.expire_latest"
+  ) || (
+    # in case we still failed, we retry the first touch command with the intention
+    # to show the (previously suppressed) error message
+    LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest"
+  )
+
+  # POSIX shell variant of bash's -nt operator, see https://unix.stackexchange.com/a/449744/6993
+  # if [ "${MILL_DOWNLOAD_PATH}/.latest" -nt "${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
+  if [ -n "$(find -L "${MILL_DOWNLOAD_PATH}/.latest" -prune -newer "${MILL_DOWNLOAD_PATH}/.expire_latest")" ]; then
+    # we know a current latest version
+    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
+  fi
+
+  if [ -z "${MILL_VERSION}" ] ; then
+    # we don't know a current latest version
+    echo "Retrieving latest mill version ..." 1>&2
+    LANG=C ${CURL_CMD} -s -i -f -I ${MILL_REPO_URL}/releases/latest 2> /dev/null  | grep --ignore-case Location: | sed s'/^.*tag\///' | tr -d '\r\n' > "${MILL_DOWNLOAD_PATH}/.latest"
+    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
+  fi
+
+  if [ -z "${MILL_VERSION}" ] ; then
+    # Last resort
+    MILL_VERSION="${DEFAULT_MILL_VERSION}"
+    echo "Falling back to hardcoded mill version ${MILL_VERSION}" 1>&2
+  else
+    echo "Using mill version ${MILL_VERSION}" 1>&2
+  fi
+fi
+
+MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
+
+try_to_use_system_mill() {
+  if [ "$(uname)" != "Linux" ]; then
+    return 0
+  fi
+
+  MILL_IN_PATH="$(command -v mill || true)"
+
+  if [ -z "${MILL_IN_PATH}" ]; then
+    return 0
+  fi
+
+  SYSTEM_MILL_FIRST_TWO_BYTES=$(head --bytes=2 "${MILL_IN_PATH}")
+  if [ "${SYSTEM_MILL_FIRST_TWO_BYTES}" = "#!" ]; then
+	  # MILL_IN_PATH is (very likely) a shell script and not the mill
+	  # executable, ignore it.
+	  return 0
+  fi
+
+  SYSTEM_MILL_PATH=$(readlink -e "${MILL_IN_PATH}")
+  SYSTEM_MILL_SIZE=$(stat --format=%s "${SYSTEM_MILL_PATH}")
+  SYSTEM_MILL_MTIME=$(stat --format=%y "${SYSTEM_MILL_PATH}")
+
+  if [ ! -d "${MILL_USER_CACHE_DIR}" ]; then
+    mkdir -p "${MILL_USER_CACHE_DIR}"
+  fi
+
+  SYSTEM_MILL_INFO_FILE="${MILL_USER_CACHE_DIR}/system-mill-info"
+  if [ -f "${SYSTEM_MILL_INFO_FILE}" ]; then
+    parseSystemMillInfo() {
+        LINE_NUMBER="${1}"
+        # Select the line number of the SYSTEM_MILL_INFO_FILE, cut the
+        # variable definition in that line in two halves and return
+        # the value, and finally remove the quotes.
+        sed -n "${LINE_NUMBER}p" "${SYSTEM_MILL_INFO_FILE}" |\
+            cut -d= -f2 |\
+            sed 's/"\(.*\)"/\1/'
+    }
+
+    CACHED_SYSTEM_MILL_PATH=$(parseSystemMillInfo 1)
+    CACHED_SYSTEM_MILL_VERSION=$(parseSystemMillInfo 2)
+    CACHED_SYSTEM_MILL_SIZE=$(parseSystemMillInfo 3)
+    CACHED_SYSTEM_MILL_MTIME=$(parseSystemMillInfo 4)
+
+    if [ "${SYSTEM_MILL_PATH}" = "${CACHED_SYSTEM_MILL_PATH}" ] \
+           && [ "${SYSTEM_MILL_SIZE}" = "${CACHED_SYSTEM_MILL_SIZE}" ] \
+           && [ "${SYSTEM_MILL_MTIME}" = "${CACHED_SYSTEM_MILL_MTIME}" ]; then
+      if [ "${CACHED_SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
+          MILL="${SYSTEM_MILL_PATH}"
+          return 0
+      else
+          return 0
+      fi
+    fi
+  fi
+
+  SYSTEM_MILL_VERSION=$(${SYSTEM_MILL_PATH} --version | head -n1 | sed -n 's/^Mill.*version \(.*\)/\1/p')
+
+  cat <<EOF > "${SYSTEM_MILL_INFO_FILE}"
+CACHED_SYSTEM_MILL_PATH="${SYSTEM_MILL_PATH}"
+CACHED_SYSTEM_MILL_VERSION="${SYSTEM_MILL_VERSION}"
+CACHED_SYSTEM_MILL_SIZE="${SYSTEM_MILL_SIZE}"
+CACHED_SYSTEM_MILL_MTIME="${SYSTEM_MILL_MTIME}"
+EOF
+
+  if [ "${SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
+    MILL="${SYSTEM_MILL_PATH}"
+  fi
+}
+try_to_use_system_mill
+
+# If not already downloaded, download it
+if [ ! -s "${MILL}" ] ; then
+
+  # support old non-XDG download dir
+  MILL_OLD_DOWNLOAD_PATH="${HOME}/.mill/download"
+  OLD_MILL="${MILL_OLD_DOWNLOAD_PATH}/${MILL_VERSION}"
+  if [ -x "${OLD_MILL}" ] ; then
+    MILL="${OLD_MILL}"
+  else
+    case $MILL_VERSION in
+      0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.* )
+        DOWNLOAD_SUFFIX=""
+        DOWNLOAD_FROM_MAVEN=0
+        ;;
+      0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M* )
+        DOWNLOAD_SUFFIX="-assembly"
+        DOWNLOAD_FROM_MAVEN=0
+        ;;
+      *)
+        DOWNLOAD_SUFFIX="-assembly"
+        DOWNLOAD_FROM_MAVEN=1
+        ;;
+    esac
+
+    DOWNLOAD_FILE=$(mktemp mill.XXXXXX)
+
+    if [ "$DOWNLOAD_FROM_MAVEN" = "1" ] ; then
+      DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/${MILL_VERSION}/mill-dist-${MILL_VERSION}.jar"
+    else
+      MILL_VERSION_TAG=$(echo "$MILL_VERSION" | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
+      DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
+      unset MILL_VERSION_TAG
+    fi
+
+    # TODO: handle command not found
+    echo "Downloading mill ${MILL_VERSION} from ${DOWNLOAD_URL} ..." 1>&2
+    ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" "${DOWNLOAD_URL}"
+    chmod +x "${DOWNLOAD_FILE}"
+    mkdir -p "${MILL_DOWNLOAD_PATH}"
+    mv "${DOWNLOAD_FILE}" "${MILL}"
+
+    unset DOWNLOAD_FILE
+    unset DOWNLOAD_SUFFIX
+  fi
+fi
+
+if [ -z "$MILL_MAIN_CLI" ] ; then
+  MILL_MAIN_CLI="${0}"
+fi
+
+MILL_FIRST_ARG=""
+if [ "$1" = "--bsp" ] || [ "$1" = "-i" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+  # Need to preserve the first position of those listed options
+  MILL_FIRST_ARG=$1
+  shift
+fi
+
+unset MILL_DOWNLOAD_PATH
+unset MILL_OLD_DOWNLOAD_PATH
+unset OLD_MILL
+unset MILL_VERSION
+unset MILL_REPO_URL
+
+# We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
+# shellcheck disable=SC2086
+exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"

--- a/project-builder/mill/prepare-project.sh
+++ b/project-builder/mill/prepare-project.sh
@@ -27,14 +27,13 @@ millVersion=
 if [[ -f .mill-version ]];then
   millVersion=`cat .mill-version`
   echo "Found explicit mill version $millVersion"
-el
 else
   echo "No .mill-version file found, detecting compatible mill version"
   if [[ -f ./mill ]];then
     millVersion=`./mill -v resolve _ | grep "[Mm]ill.*version" | grep -E -o "(\d+\.?){3}"`
   else 
     for v in $MILL_0_11 $MILL_0_10 $MILL_0_9; do
-      if ${scriptDir}/millw --mill-version $v $RESOLVE; then
+      if ${scriptDir}/millw --mill-version $v $RESOLVE > /dev/null 2>/dev/null; then
         millVersion=$v
         break
       fi

--- a/project-builder/mill/prepare-project.sh
+++ b/project-builder/mill/prepare-project.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-if [ $# -ne 7 ]; then
-  echo "Wrong number of script arguments, expected 3 $0 <repo_dir> <scala_version> <publish_version> <extra-scalacOption> <disabled-scalacOptions>, got $#: $@"
+if [ $# -ne 5 ]; then
+  echo "Wrong number of script arguments, expected 3 $0 <repo_dir> <scala_version> <publish_version>, got $#: $@"
   exit 1
 fi
 
@@ -12,8 +12,6 @@ repoDir="$2" # e.g. /tmp/shapeless
 scalaVersion="$3" # e.g. 3.1.2-RC1
 publishVersion="$4" # version of the project
 projectConfig="$5" 
-extraScalacOptions="$6"
-disabledScalacOption="$7"
 
 export OPENCB_PROJECT_DIR=$repoDir
 
@@ -106,8 +104,6 @@ cp build.sc build.scala \
     --settings.Scala3CommunityBuildMillAdapter.targetScalaVersion "$scalaVersion" \
     --settings.Scala3CommunityBuildMillAdapter.targetPublishVersion "$publishVersion" \
     --settings.Scala3CommunityBuildMillAdapter.millBinaryVersion "$millBinaryVersion" \
-    --settings.Scala3CommunityBuildMillAdapter.appendScalacOptions "$extraScalacOptions" \
-    --settings.Scala3CommunityBuildMillAdapter.removeScalacOptions "$disabledScalacOption" \
     --scala-version 3.1.0 > build.sc \
   && rm build.scala 
 

--- a/project-builder/mill/scalafix/input/src/main/scala/fix/MillScalacOptionsOverride.scala
+++ b/project-builder/mill/scalafix/input/src/main/scala/fix/MillScalacOptionsOverride.scala
@@ -4,6 +4,9 @@ rule = Scala3CommunityBuildMillAdapter
 package fix
 
 object MillScalacOptionsOverride {
+  object MillCommunityBuild{
+    def mapScalacOptions(current: Seq[String]): Seq[String] = ???
+  }
   def scalacOptions = List.empty[String]
   object mill{
     import scala.language.implicitConversions

--- a/project-builder/mill/scalafix/input/src/main/scala/fix/MillScalacOptionsOverride.scala
+++ b/project-builder/mill/scalafix/input/src/main/scala/fix/MillScalacOptionsOverride.scala
@@ -23,6 +23,11 @@ object MillScalacOptionsOverride {
   object module2 {
     def scalacOptions: Seq[String] = Seq("-Xprint:typer")
   }
+  
+  object module3 {
+    def scalacOptions = mill.T(module2.scalacOptions)
+  }
+  
   class moduleDef {
     def scalacOptions: T[Seq[String]] = {
       val opt1 = "-release:11"

--- a/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalacOptionsOverride.scala
+++ b/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalacOptionsOverride.scala
@@ -1,7 +1,10 @@
 package fix
 
 object MillScalacOptionsOverride {
-  def scalacOptions = { List.empty[String] }.diff(Seq("R1","R2")).diff(Seq("A1","A2")).appendedAll(Seq("A1","A2")).distinct
+  object MillCommunityBuild{
+    def mapScalacOptions(current: Seq[String]): Seq[String] = ???
+  }
+  def scalacOptions = MillCommunityBuild.mapScalacOptions{ List.empty[String] }
   object mill{
     import scala.language.implicitConversions
     trait T[U]
@@ -12,23 +15,23 @@ object MillScalacOptionsOverride {
   import mill._
 
   object module {
-    val scalacOptions = { Nil }.diff(Seq("R1","R2")).diff(Seq("A1","A2")).appendedAll(Seq("A1","A2")).distinct
+    val scalacOptions = MillCommunityBuild.mapScalacOptions{ Nil }
   }
   object module2 {
-    def scalacOptions: Seq[String] = { Seq("-Xprint:typer") }.diff(Seq("R1","R2")).diff(Seq("A1","A2")).appendedAll(Seq("A1","A2")).distinct
+    def scalacOptions: Seq[String] = MillCommunityBuild.mapScalacOptions{ Seq("-Xprint:typer") }
   }
   class moduleDef {
-    def scalacOptions: T[Seq[String]] = {
-      { val opt1 = "-release:11"
-      Seq(opt1) }.diff(Seq("R1","R2")).diff(Seq("A1","A2")).appendedAll(Seq("A1","A2")).distinct
-    }
+    def scalacOptions: T[Seq[String]] = MillCommunityBuild.mapScalacOptions{ {
+      val opt1 = "-release:11"
+      Seq(opt1)
+    } }
   }
   class moduleDef2 extends moduleDef {
-    override val scalacOptions: T[Seq[String]] = { MillScalacOptionsOverride.scalacOptions }.diff(Seq("R1","R2")).diff(Seq("A1","A2")).appendedAll(Seq("A1","A2")).distinct
+    override val scalacOptions: T[Seq[String]] = MillCommunityBuild.mapScalacOptions{ MillScalacOptionsOverride.scalacOptions }
   }
   object moduleDef3 extends moduleDef {
     override def scalacOptions = T {
-      { super.scalacOptions ++ Nil }.diff(Seq("R1","R2")).diff(Seq("A1","A2")).appendedAll(Seq("A1","A2")).distinct
+      MillCommunityBuild.mapScalacOptions{ super.scalacOptions ++ Nil }
     }
   }
  

--- a/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalacOptionsOverride.scala
+++ b/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalacOptionsOverride.scala
@@ -20,6 +20,11 @@ object MillScalacOptionsOverride {
   object module2 {
     def scalacOptions: Seq[String] = MillCommunityBuild.mapScalacOptions{ Seq("-Xprint:typer") }
   }
+  
+  object module3 {
+    def scalacOptions = mill.T(MillCommunityBuild.mapScalacOptions{ module2.scalacOptions })
+  }
+  
   class moduleDef {
     def scalacOptions: T[Seq[String]] = MillCommunityBuild.mapScalacOptions{ {
       val opt1 = "-release:11"

--- a/project-builder/mill/scalafix/rules/src/main/scala/fix/Scala3CommunityBuildMillAdapter.scala
+++ b/project-builder/mill/scalafix/rules/src/main/scala/fix/Scala3CommunityBuildMillAdapter.scala
@@ -125,8 +125,11 @@ class Scala3CommunityBuildMillAdapter(
 
       case tree @ ValOrDefDef(Term.Name("scalacOptions"), tpe, body) =>
         val (beforeNode, afterNode) = body match {
-          case scala.meta.Term.Apply(Term.Name("T"), (block: scala.meta.Term.Block) :: Nil) =>
-            (block.stats.head, block.stats.last)
+          case scala.meta.Term.Apply(Term.Name("T") | Term.Select(_, Term.Name("T")), arg :: Nil) =>
+            arg match {
+              case block: scala.meta.Term.Block => (block.stats.head, block.stats.last)
+              case arg                          => (arg, arg)
+            }
           case tree => (tree, tree)
         }
         List(


### PR DESCRIPTION
* Share algorith of filtering and adding scalacOptions 
* Move mill scalacOptions setting to runtime, resolve from sys properties 
* Improve mill version detection, don't use coursier, instead fallback to millw. Always build with detected version if no ./mill file script found 
* Always set -source:3.x-migration flag 
* Always set/remove some of common scalacOptions (deprecations, fatal warning, linting)