### PR TITLE
Add smithy-playground to custom projects

### DIFF
--- a/coordinator/configs/custom-projects.txt
+++ b/coordinator/configs/custom-projects.txt
@@ -1,5 +1,6 @@
 epfl-lara/lisa
 gvolpe/trading
+kubukoz/smithy-playground
 lichess-org/lila
 lichess-org/lila-fishnet
 lichess-org/lila-search


### PR DESCRIPTION
As per suggestion by @WojciechMazur - playground is an LSP server so it shouldn't be counted as a library.