### PR TITLE
Remove test filtering for jsoniter-scala

### DIFF
--- a/coordinator/configs/projects-config.conf
+++ b/coordinator/configs/projects-config.conf
@@ -1195,7 +1195,7 @@ playframework_twirl{
   }]
 }
 plokhotnyuk_jsoniter-scala {
-  sbt.commands = ["""set every Test/unmanagedSources/excludeFilter := HiddenFileFilter || "JsonCodecMakerNewTypeSpec.scala" """]
+  sbt.commands = ["""set every Test/unmanagedSources/excludeFilter := HiddenFileFilter """]
 }
 polynote_uzhttp {
   source-patches = [


### PR DESCRIPTION
I fixed Scala Next incompatibilities in the tests.

Now all tests for all modules pass successfully with the following command: `sbt ++3.7.3! clean test`