### PR TITLE
Fix Mill 1.x API drift in community-build harness

### DIFF
--- a/project-builder/mill/MillCommunityBuild.scala
+++ b/project-builder/mill/MillCommunityBuild.scala
@@ -4,7 +4,7 @@ package millbuild
 import mill.Module
 import mill.api.{Val, Task, ModuleRef, Result, Evaluator}
 import mill.api.daemon.Segment
-import mill.javalib.JvmWorkerModule
+import mill.javalib.{Dep, JvmWorkerModule}
 import mill.javalib.testrunner.TestResult
 import mill.javalib.api.CompilationResult
 import mill.scalalib.{CoursierModule, JavaModule, PublishModule, ScalaModule, TestModule}
@@ -46,6 +46,13 @@ object MillCommunityBuild {
     private object CommunityBuildJvmWorker extends JvmWorkerModule with CoursierModule:
       override def repositoriesTask = Task.Anon:
         mavenRepo.foldLeft(super.repositoriesTask())(_ :+ _)
+
+    // Break diamond inheritance when this trait is mixed into a TestModule
+    // alongside JavaModule (e.g. `extends TestModule.ScalaTest with
+    // CommunityBuildCoursierModule`). The `super.` calls resolve via the
+    // concrete class's linearization, so the TestModule overrides win.
+    override def defaultTask(): String = super.defaultTask()
+    override def mandatoryMvnDeps: mill.T[Seq[Dep]] = Task { super.mandatoryMvnDeps() }
   }
 
   // Extension to publish module allowing to upload artifacts to custom maven repo
@@ -167,9 +174,9 @@ object MillCommunityBuild {
         case Result.Success(v) =>
           ctx.log.info(s"Successfully evaluated $task")
           EvalResult.Value(v, evalTime = tookMillis)
-        case Result.Failure(error) =>
-          ctx.log.error(s"Failed to evaluated $task: ${error}")
-          EvalResult.Failure(EvaluationFailure(error) :: Nil, evalTime = tookMillis)
+        case f: Result.Failure =>
+          ctx.log.error(s"Failed to evaluated $task: ${f.error}")
+          EvalResult.Failure(EvaluationFailure(f.error) :: Nil, evalTime = tookMillis)
       }
     }
 

--- a/project-builder/prepare-scripts/com-lihaoyi/mill
+++ b/project-builder/prepare-scripts/com-lihaoyi/mill
@@ -4,16 +4,11 @@
 val projectDir = sys.env.get("OPENCB_PROJECT_DIR")
   .map(os.Path(_))
   .getOrElse(sys.error("no OPENCB_PROJECT_DIR env"))
-  
+
 os.write.append(projectDir / ".mill-jvm-opts", "-XX:CompressedClassSpaceSize=1400m")
-  
+
 val scalaVersion = sys.env.get("OPENCB_SCALA_VERSION")
    .getOrElse(sys.error("no OPENCB_SCALA_VERSION env"))
-
-val minJDKVersion = scalaVersion.split('.').take(2).map(_.toInt) match {
-  case Array(3, minor) if minor >= 8  => 17
-  case _ => 8
-}
 
 val millDefsVersion = os.read
   .lines(projectDir / "mill-build"/ "src" / "millbuild"/ "Deps.scala")
@@ -25,14 +20,6 @@ val millDefsVersion = os.read
 val repositoryDir = os.temp.dir(prefix = "mill-moduledefs-")
 os.proc("git", "clone", "https://github.com/com-lihaoyi/mill-moduledefs", repositoryDir, "-b", millDefsVersion).call(check = true)
 
-val updatedBuild = os.read(repositoryDir / "build.sc")
-  .replaceAll(raw"Cross\[ModuleDefsCross]\(.*\)", s"""Cross[ModuleDefsCross](Seq("3.7.1"))""")
-  .replaceAll(raw"Cross\[PluginCross]\(.*\)", s"""Cross[PluginCross](Seq("$scalaVersion"))""")
-  .replace(""""-Yexplicit-nulls",""", "")
-  .replace(""""-java-output-version", "8""", s""""-java-output-version:${minJDKVersion}""")
-os.write.over(repositoryDir / "build.sc", updatedBuild)
-os.write.over(repositoryDir / ".mill-version", "0.12.15-2-561986")
-
 val coursierRepositories = Seq(
   "central",
   "ivy2local",
@@ -40,9 +27,16 @@ val coursierRepositories = Seq(
   s"https://scala3.westeurope.cloudapp.azure.com/maven2/$scalaVersion",
 ).mkString("|")
 
+// mill-moduledefs's `build.mill` already adds `SCALA_VERSION` from the env to
+// its Scala 3 cross matrix, and self-declares the Mill version via the
+// `//| mill-version: …` magic comment, so we just pass the env through.
 os.proc(
   "./mill",
   "--no-server",
   "-D", s"coursier.repositories=$coursierRepositories",
   "show", s"__[$scalaVersion].publishLocal",
-).call(cwd = repositoryDir, check = true)
+).call(
+  cwd = repositoryDir,
+  env = Map("SCALA_VERSION" -> scalaVersion),
+  check = true,
+)

--- a/project-builder/prepare-scripts/com-lihaoyi/mill
+++ b/project-builder/prepare-scripts/com-lihaoyi/mill
@@ -10,6 +10,11 @@ os.write.append(projectDir / ".mill-jvm-opts", "-XX:CompressedClassSpaceSize=140
 val scalaVersion = sys.env.get("OPENCB_SCALA_VERSION")
    .getOrElse(sys.error("no OPENCB_SCALA_VERSION env"))
 
+val minJDKVersion = scalaVersion.split('.').take(2).map(_.toInt) match {
+  case Array(3, minor) if minor >= 8  => 17
+  case _ => 8
+}
+
 val millDefsVersion = os.read
   .lines(projectDir / "mill-build"/ "src" / "millbuild"/ "Deps.scala")
   .map(_.trim)
@@ -27,9 +32,32 @@ val coursierRepositories = Seq(
   s"https://scala3.westeurope.cloudapp.azure.com/maven2/$scalaVersion",
 ).mkString("|")
 
-// mill-moduledefs's `build.mill` already adds `SCALA_VERSION` from the env to
-// its Scala 3 cross matrix, and self-declares the Mill version via the
-// `//| mill-version: …` magic comment, so we just pass the env through.
+// mill-moduledefs migrated from `build.sc` (Mill 0.x cross-style) to
+// `build.mill` (Mill 1.x, env-driven cross matrix) at version 0.13.x. We
+// support both because mill@1.0.x still pins moduledefs 0.11.x while
+// mill@1.1.x pins 0.13.x.
+val buildMill = repositoryDir / "build.mill"
+val buildSc = repositoryDir / "build.sc"
+
+val extraEnv: Map[String, String] = if (os.exists(buildMill)) {
+  // 0.13.x+: `build.mill` reads SCALA_VERSION from env and self-declares its
+  // mill version via `//| mill-version: …`, so just pass the env through.
+  Map("SCALA_VERSION" -> scalaVersion)
+} else if (os.exists(buildSc)) {
+  // 0.11.x/0.12.x: `build.sc` hard-codes its cross matrix and scalacOptions,
+  // so patch the requested Scala version in.
+  val updatedBuild = os.read(buildSc)
+    .replaceAll(raw"Cross\[ModuleDefsCross]\(.*\)", s"""Cross[ModuleDefsCross](Seq("3.7.1"))""")
+    .replaceAll(raw"Cross\[PluginCross]\(.*\)", s"""Cross[PluginCross](Seq("$scalaVersion"))""")
+    .replace(""""-Yexplicit-nulls",""", "")
+    .replace(""""-java-output-version", "8""", s""""-java-output-version:${minJDKVersion}""")
+  os.write.over(buildSc, updatedBuild)
+  os.write.over(repositoryDir / ".mill-version", "0.12.15-2-561986")
+  Map.empty
+} else {
+  sys.error(s"mill-moduledefs $millDefsVersion has neither build.mill nor build.sc")
+}
+
 os.proc(
   "./mill",
   "--no-server",
@@ -37,6 +65,6 @@ os.proc(
   "show", s"__[$scalaVersion].publishLocal",
 ).call(
   cwd = repositoryDir,
-  env = Map("SCALA_VERSION" -> scalaVersion),
+  env = extraEnv,
   check = true,
 )


### PR DESCRIPTION
Three independent fixes for the BUILD:mill failures surfaced against the 2026-05-01 Scala 3.9.0 nightly community build:

* `Result.Failure` shape: Mill 1.x widened `Result.Failure` from 1-arg `(error)` to 6-arg `(error, path, index, exception, tickerPrefix, next)`. Bind the failure by type and use `.error` instead of destructuring. Affects ~18 of 23 failing projects (case-app, almond, upickle, utest, scala-cli, etc.).

* `defaultTask` / `mandatoryMvnDeps` diamond: when `CommunityBuildCoursierModule` is mixed in alongside `TestModule.ScalaTest` (e.g. `reactivecore/datacomparison`'s `SharedTestModule`), Scala 3 can't auto-resolve the override conflict between `TestModule` and `JavaModule`. Add explicit `super.` overrides; trait-`super` resolves via the concrete class's linearization so the `TestModule` overrides still win at runtime.

* `com-lihaoyi/mill` prepare-script: `mill-moduledefs` migrated to Mill 1.x (`build.mill`, no `build.sc`). The `Cross[ModuleDefsCross]`, `Cross[PluginCross]`, `-Yexplicit-nulls` and `-java-output-version` text substitutions are dead. The new `build.mill` already reads `SCALA_VERSION` from the env and self-declares its Mill version via `//| mill-version`, so just pass the env through and drop the patching.