### PR TITLE
Filter out rchillyard/gryphon (requires JDK 21)

### DIFF
--- a/coordinator/configs/filtered-projects.txt
+++ b/coordinator/configs/filtered-projects.txt
@@ -338,6 +338,8 @@ dicklieber:wa9nnn-util:.*
 armanbilge:cheshire:.*
 ## Requires JDK 22
 argon-lang:async-util:.*
+## Requires JDK 21
+rchillyard:gryphon:.*
 
 ## Double build tools
 nau:scalus:.*


### PR DESCRIPTION
The gryphon project requires JDK 21, which is not available in the community build environment, causing it to fail. Exclude it from the build until the build environment supports JDK 21.