### PR TITLE
Fix facsimile/facsimile build for Scala 3.9 OpenCB

### DIFF
--- a/coordinator/configs/projects-config.conf
+++ b/coordinator/configs/projects-config.conf
@@ -606,6 +606,7 @@ etorreborre_specs2 {
 }
 
 facsimile_facsimile{
+  sbt.commands = ["""mapScalacOptions "-rewrite,-source:3.7-migration" """]
   source-patches = [
     # -Yexplicit-nulls
     {


### PR DESCRIPTION
Adds `-rewrite -source:3.7-migration` scalacOptions so the compiler auto-rewrites the sources to satisfy 3.9 syntax requirements.