### PR TITLE
Remove jsonrpclib from filtered-projects.txt

### DIFF
--- a/coordinator/configs/filtered-projects.txt
+++ b/coordinator/configs/filtered-projects.txt
@@ -118,9 +118,6 @@ e257-fi:dirsuite:.*
 ### scaladex lists only 1 Scala 3 project zio-resource in version 0.0.1 which is more recent then existing 0.1.12 version with only Scala 2 projects
 carlos-verdes:funkode:0.[0-1]\..*
 
-## Uses mill-tpolecat - it does fails to parse RC versions
-neandertech:jsonrpclib:.*
-
 ## Missing artifacts in public repo
 # sbt-beangle-parent:0.6.0
 beangle:data:.*


### PR DESCRIPTION
It doesn't use mill-tpolecat anymore (or Mill, for that matter).