### PR TITLE
Don't build zio-archive/zio-jdbc with -source:3.5+

### DIFF
--- a/coordinator/configs/require/source-migration-rewrite/3.7
+++ b/coordinator/configs/require/source-migration-rewrite/3.7
@@ -129,7 +129,6 @@ vitaliihonta/scala-ql
 wangzaixiang/wjson
 xebia-functional/munit-compiler-toolkit
 zero-deps/proto
-zio-archive/zio-jdbc
 zio/zio
 zio/zio-config
 zio/zio-http

--- a/coordinator/configs/require/source-version/3.4
+++ b/coordinator/configs/require/source-version/3.4
@@ -11,3 +11,4 @@ taig/backmail
 taig/geojson
 scalatest/scalatest
 typelevel/fs2-kafka
+zio-archive/zio-jdbc


### PR DESCRIPTION

`zio-archive/zio-jdbc` doesn't compile under `-source:3.5+`, it passes context bound parameters with `using`, which doesn't compile with `-source:3.5+`.
See: https://github.com/scala/scala3/issues/26003

```scala
JdbcEncoder.tuple2Encoder(self.fromSchema(left), self.fromSchema(right))

// JdbcEncoder
implicit def tuple2Encoder[A: JdbcEncoder, B: JdbcEncoder]: JdbcEncoder[(A, B)] = …
```

This commit removes `zio-archive/zio-jdbc` from `3.7-migration`, and add it to `3.4`.
