### PR TITLE
[coordinator] Auto-update zio deps to workaround broken macros

### DIFF
--- a/coordinator/src/main/resources/buildPlan.reference.conf
+++ b/coordinator/src/main/resources/buildPlan.reference.conf
@@ -60,3 +60,9 @@ git {
 // Allowed constant values: 
 // * SCALA_VERSION - Scala version that would be used to run the build
 source-patches = []
+
+# Forced dependency versions for sbt dependencyOverrides, scala-cli format:
+#   org::artifact:version  (%% cross)
+#   org:artifact:version   (Java / no cross)
+# Empty by default; discovery or projects-config.conf may populate.
+dependency-overrides = []

--- a/coordinator/src/main/scala/ProjectBuildDefCache.scala
+++ b/coordinator/src/main/scala/ProjectBuildDefCache.scala
@@ -113,6 +113,11 @@ object ProjectBuildDefCache:
     discovery.requireConfigBytes(project).foreach { case (label, bytes) =>
       update(label, bytes)
     }
+    update(
+      "zio-discovery",
+      ZioDependencyOverrideDiscovery.DiscoveryRulesVersion
+        .getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    )
     update("replacement", replacementLine(project, confFiles).getBytes(java.nio.charset.StandardCharsets.UTF_8))
     digest.digest().map("%02x".format(_)).mkString
 

--- a/coordinator/src/main/scala/ProjectConfigDiscovery.scala
+++ b/coordinator/src/main/scala/ProjectConfigDiscovery.scala
@@ -126,6 +126,13 @@ class ProjectConfigDiscovery(internalProjectConfigsPath: java.io.File, requiredC
                 else projectTestsConfig.get(project.p).foldLeft(c) { (c, value) =>
                   c.copy(tests = value)
                 }
+              .map: c =>
+                c.copy(dependencyOverrides =
+                  mergeDependencyOverrides(
+                    c.dependencyOverrides,
+                    ZioDependencyOverrideDiscovery.discover(project, projectDir)
+                  )
+                )
               .filter(_ != ProjectBuildConfig.empty)
           } catch {
             case ex: Throwable =>
@@ -345,4 +352,12 @@ class ProjectConfigDiscovery(internalProjectConfigsPath: java.io.File, requiredC
         Nil
     }
   }
+
+  /** Manual overrides win on the same org+artifact key; discovery fills the rest. */
+  private def mergeDependencyOverrides(
+      manual: List[DependencyOverride],
+      discovered: List[DependencyOverride]
+  ): List[DependencyOverride] =
+    val manualKeys = manual.map(_.moduleKey).toSet
+    manual ++ discovered.filterNot(d => manualKeys.contains(d.moduleKey))
 }

--- a/coordinator/src/main/scala/ZioDependencyOverrideDiscovery.scala
+++ b/coordinator/src/main/scala/ZioDependencyOverrideDiscovery.scala
@@ -4,15 +4,15 @@ import scala.collection.mutable
 import org.jsoup.Jsoup
 
 /** Discover ZIO core modules that need a force-upgrade for Scala 3.10 Tracer fixes.
-  * Skips ZIO 1.x and ZIO 2.0.0 milestones / RCs entirely. Only emits overrides when
-  * current version &lt; [[ForceVersion]].
+  * Skips ZIO 1.x and 2.0.0-RCx projects entirely. Only emits overrides when current
+  * version &lt; [[ForceVersion]].
   */
 object ZioDependencyOverrideDiscovery:
   val ForceVersion = "2.1.26"
   private val ForceSemVersion = SemVersion(2, 1, 26)
 
   /** Bump when discovery skip/force rules change so [[ProjectBuildDefCache]] invalidates. */
-  val DiscoveryRulesVersion = "skip-1.x+skip-2.0.0-M/RC+force-2.1.26-7+transitive-zio-pom-graph"
+  val DiscoveryRulesVersion = "1.0"
 
   /** Core JVM modules from https://index.scala-lang.org/zio/zio/artifacts/zio
     * that share the `dev.zio` version line (excludes interop / examples / tests).
@@ -48,7 +48,7 @@ object ZioDependencyOverrideDiscovery:
     "zio-test-refined",
   )
 
-  private val Zio200PreRelease = raw"(?i)2\.0\.0-(?:M|RC)\d+.*".r
+  private val Zio200Rc = raw"(?i)2\.0\.0-RC\d+.*".r
   private val QuotedVersion = raw""""(2\.\d+\.\d+[^"]*)"""".r
   private val ZioVersionAssign =
     raw"""(?i)zio(?:Version|Ver|_version)\s*=\s*"([^"]+)"""".r
@@ -79,9 +79,9 @@ object ZioDependencyOverrideDiscovery:
                     .mkString(", ")})"
               )
               Nil
-            else if coreDeps.exists(dep => isZio200PreRelease(dep.version)) then
+            else if coreDeps.exists(dep => isZio200Rc(dep.version)) then
               println(
-                s"Skipping ZIO dependencyOverrides for ${project.p.coordinates}: uses ZIO 2.0.0 milestone / RC (${coreDeps
+                s"Skipping ZIO dependencyOverrides for ${project.p.coordinates}: uses ZIO 2.0.0-RC (${coreDeps
                     .map(dep => s"${dep.logicalName}:${dep.version}")
                     .mkString(", ")})"
               )
@@ -114,7 +114,7 @@ object ZioDependencyOverrideDiscovery:
         else Nil
       val versions = (assigned ++ quoted).distinct
       if versions.exists(isZio1) then Some("uses ZIO 1.x")
-      else if versions.exists(isZio200PreRelease) then Some("uses ZIO 2.0.0 milestone / RC")
+      else if versions.exists(isZio200Rc) then Some("uses ZIO 2.0.0-RC")
       else None
 
   private def buildSourceFiles(projectDir: os.Path): List[os.Path] =
@@ -139,12 +139,12 @@ object ZioDependencyOverrideDiscovery:
     val v = version.trim
     SemVersion.unapply(v).exists(_.major == 1) || v.startsWith("1.")
 
-  /** ZIO 2.0.0 pre-releases (e.g. `2.0.0-M5`, `2.0.0-RC5`) — do not force-upgrade to 2.1.x. */
-  private def isZio200PreRelease(version: String): Boolean =
-    version.trim.matches(Zio200PreRelease.regex)
+  /** ZIO 2.0.0 release candidates (e.g. `2.0.0-RC5`) — do not force-upgrade to 2.1.x. */
+  private def isZio200Rc(version: String): Boolean =
+    version.trim.matches(Zio200Rc.regex)
 
   private def needsForceUpgrade(version: String): Boolean =
-    if isZio1(version) || isZio200PreRelease(version) then false
+    if isZio1(version) || isZio200Rc(version) then false
     else
       SemVersion.unapply(version) match
         case Some(v) => v < ForceSemVersion
@@ -174,15 +174,15 @@ object ZioDependencyOverrideDiscovery:
             val id = a.obj.get("artifactId").map(_.str).getOrElse("")
             id.endsWith("_3") || a.obj.get("language").exists(_.str == "3")
         case matched => matched
-    val artOpt = matching
+    val candidateArtifacts = matching
       .sortBy: a =>
         val id = a.obj.get("artifactId").map(_.str).getOrElse("")
         if id.endsWith("_3") then 0 else 1
-      .headOption
-
-    artOpt match
-      case None => Nil
-      case Some(art) =>
+    // Inspect all published Scala 3 artifacts for the project version. Some projects,
+    // like guinep, use ZIO only from a secondary module (e.g. `guinep-web` via zio-http),
+    // and looking at a single artifact misses the transitive `dev.zio` graph entirely.
+    candidateArtifacts
+      .flatMap: art =>
         val groupId = art("groupId").str
         val artifactId = art("artifactId").str
         val tryVersions =
@@ -193,6 +193,7 @@ object ZioDependencyOverrideDiscovery:
             catch case _: Exception => None
           .headOption
           .getOrElse(Nil)
+      .distinctBy(dep => dep.artifactId -> dep.version)
 
   private def loadPublishedDevZioDeps(artifactId: String, version: String): List[ZioDep] =
     try loadPomDevZioDeps("dev.zio", artifactId, version)

--- a/coordinator/src/main/scala/ZioDependencyOverrideDiscovery.scala
+++ b/coordinator/src/main/scala/ZioDependencyOverrideDiscovery.scala
@@ -1,0 +1,307 @@
+import scala.jdk.CollectionConverters.*
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import org.jsoup.Jsoup
+
+/** Discover ZIO core modules that need a force-upgrade for Scala 3.10 Tracer fixes.
+  * Skips ZIO 1.x and ZIO 2.0.0 milestones / RCs entirely. Only emits overrides when
+  * current version &lt; [[ForceVersion]].
+  */
+object ZioDependencyOverrideDiscovery:
+  val ForceVersion = "2.1.26"
+  private val ForceSemVersion = SemVersion(2, 1, 26)
+
+  /** Bump when discovery skip/force rules change so [[ProjectBuildDefCache]] invalidates. */
+  val DiscoveryRulesVersion = "skip-1.x+skip-2.0.0-M/RC+force-2.1.26-7+transitive-zio-pom-graph"
+
+  /** Core JVM modules from https://index.scala-lang.org/zio/zio/artifacts/zio
+    * that share the `dev.zio` version line (excludes interop / examples / tests).
+    *
+    * Dependency graph at 2.1.26 (compile scope):
+    * {{{
+    * zio-stacktracer ─┐
+    * zio-internal-macros ─┼─► zio ─┬─► zio-streams ─┬─► zio-managed ─► zio-macros
+    *                      │        ├─► zio-concurrent│
+    *                      │        └─► zio-test ─────┴─► zio-test-{sbt,junit,junit-engine,scalacheck,magnolia}
+    *                                                      └─► zio-test-refined (via magnolia)
+    * }}}
+    * When any of these needs a force-upgrade we override the full set: eviction often
+    * leaves companions (esp. stacktracer) pinned while nightlies fail to resolve them.
+    */
+  private val CoreArtifacts: Set[String] = Set(
+    // roots / companions of zio
+    "zio-stacktracer",
+    "zio-internal-macros",
+    "zio",
+    // direct downstream of zio
+    "zio-streams",
+    "zio-concurrent",
+    "zio-managed",
+    "zio-macros",
+    "zio-test",
+    // downstream of zio-test
+    "zio-test-sbt",
+    "zio-test-junit",
+    "zio-test-junit-engine",
+    "zio-test-scalacheck",
+    "zio-test-magnolia",
+    "zio-test-refined",
+  )
+
+  private val Zio200PreRelease = raw"(?i)2\.0\.0-(?:M|RC)\d+.*".r
+  private val QuotedVersion = raw""""(2\.\d+\.\d+[^"]*)"""".r
+  private val ZioVersionAssign =
+    raw"""(?i)zio(?:Version|Ver|_version)\s*=\s*"([^"]+)"""".r
+  private val Placeholder = """\$\{([^}]+)\}""".r
+
+  private case class ZioDep(logicalName: String, artifactId: String, version: String)
+
+  private val DevZioPomDepsCache = TrieMap.empty[(String, String, String), List[ZioDep]]
+
+  def discover(project: ProjectVersion, projectDir: os.Path): List[DependencyOverride] =
+    try
+      sourceSkipReason(projectDir) match
+        case Some(reason) =>
+          println(
+            s"Skipping ZIO dependencyOverrides for ${project.p.coordinates}: $reason (from sources)"
+          )
+          Nil
+        case None =>
+          val directZioDeps = loadDirectZioMavenDeps(project)
+          if directZioDeps.isEmpty then Nil
+          else
+            val coreDeps = reachableCoreDeps(directZioDeps)
+            if coreDeps.isEmpty then Nil
+            else if coreDeps.exists(dep => isZio1(dep.version)) then
+              println(
+                s"Skipping ZIO dependencyOverrides for ${project.p.coordinates}: uses ZIO 1.x (${coreDeps
+                    .map(dep => s"${dep.logicalName}:${dep.version}")
+                    .mkString(", ")})"
+              )
+              Nil
+            else if coreDeps.exists(dep => isZio200PreRelease(dep.version)) then
+              println(
+                s"Skipping ZIO dependencyOverrides for ${project.p.coordinates}: uses ZIO 2.0.0 milestone / RC (${coreDeps
+                    .map(dep => s"${dep.logicalName}:${dep.version}")
+                    .mkString(", ")})"
+              )
+              Nil
+            else if !coreDeps.exists(dep => needsForceUpgrade(dep.version)) then Nil
+            else
+              // Force the full core set once any reachable core dep needs it, even when
+              // the project only declares a downstream/non-core `dev.zio` module directly.
+              CoreArtifacts.toList
+                .map(artifact => DependencyOverride.scala("dev.zio", artifact, ForceVersion))
+                .distinctBy(_.moduleKey)
+    catch
+      case ex: Exception =>
+        Console.err.println(
+          s"Failed to discover ZIO dependencyOverrides for ${project.p.coordinates}: $ex"
+        )
+        Nil
+
+  /** Prefer build sources over Maven: community-build compiles the git checkout. */
+  private def sourceSkipReason(projectDir: os.Path): Option[String] =
+    val text = buildSourceFiles(projectDir)
+      .flatMap(path => util.Try(os.read(path)).toOption)
+      .mkString("\n")
+    if !text.contains("dev.zio") && !ZioVersionAssign.findFirstIn(text).isDefined then None
+    else
+      val assigned = ZioVersionAssign.findAllMatchIn(text).map(_.group(1)).toList
+      val quoted =
+        if text.contains("dev.zio") then
+          QuotedVersion.findAllMatchIn(text).map(_.group(1)).toList
+        else Nil
+      val versions = (assigned ++ quoted).distinct
+      if versions.exists(isZio1) then Some("uses ZIO 1.x")
+      else if versions.exists(isZio200PreRelease) then Some("uses ZIO 2.0.0 milestone / RC")
+      else None
+
+  private def buildSourceFiles(projectDir: os.Path): List[os.Path] =
+    val rootFiles = List(
+      projectDir / "build.sbt",
+      projectDir / "build.sc",
+      projectDir / "build.scala",
+      projectDir / "build.mill",
+      projectDir / "Dependencies.scala",
+      projectDir / "project" / "Dependencies.scala",
+      projectDir / "project" / "deps.scala",
+      projectDir / "project" / "Deps.scala"
+    )
+    val projectDirFiles =
+      val dir = projectDir / "project"
+      if os.exists(dir) && os.isDir(dir) then
+        os.list(dir).filter(p => os.isFile(p) && (p.ext == "scala" || p.ext == "sbt")).toList
+      else Nil
+    (rootFiles ++ projectDirFiles).filter(os.isFile).distinct
+
+  private def isZio1(version: String): Boolean =
+    val v = version.trim
+    SemVersion.unapply(v).exists(_.major == 1) || v.startsWith("1.")
+
+  /** ZIO 2.0.0 pre-releases (e.g. `2.0.0-M5`, `2.0.0-RC5`) — do not force-upgrade to 2.1.x. */
+  private def isZio200PreRelease(version: String): Boolean =
+    version.trim.matches(Zio200PreRelease.regex)
+
+  private def needsForceUpgrade(version: String): Boolean =
+    if isZio1(version) || isZio200PreRelease(version) then false
+    else
+      SemVersion.unapply(version) match
+        case Some(v) => v < ForceSemVersion
+        case None    => false
+
+  private def reachableCoreDeps(startDeps: List[ZioDep]): List[ZioDep] =
+    val queue = mutable.Queue.from(startDeps)
+    val visited = mutable.Set.empty[(String, String)]
+    val reachable = mutable.ArrayBuffer.empty[ZioDep]
+    while queue.nonEmpty do
+      val dep = queue.dequeue()
+      val key = dep.artifactId -> dep.version
+      if visited.add(key) then
+        if CoreArtifacts.contains(dep.logicalName) then reachable += dep
+        loadPublishedDevZioDeps(dep.artifactId, dep.version).foreach(queue.enqueue(_))
+    reachable.toList.distinctBy(dep => dep.logicalName -> dep.version)
+
+  private def loadDirectZioMavenDeps(project: ProjectVersion): List[ZioDep] =
+    val artifactsUrl =
+      s"https://index.scala-lang.org/api/v1/projects/${project.p.organization}/${project.p.repository}/artifacts?stable-only=false"
+    val artifactsJson = httpGet(artifactsUrl)
+    val artifacts = ujson.read(artifactsJson).arr.toList
+    val matching =
+      artifacts.filter(a => a.obj.get("version").exists(_.str == project.v)) match
+        case Nil =>
+          artifacts.filter: a =>
+            val id = a.obj.get("artifactId").map(_.str).getOrElse("")
+            id.endsWith("_3") || a.obj.get("language").exists(_.str == "3")
+        case matched => matched
+    val artOpt = matching
+      .sortBy: a =>
+        val id = a.obj.get("artifactId").map(_.str).getOrElse("")
+        if id.endsWith("_3") then 0 else 1
+      .headOption
+
+    artOpt match
+      case None => Nil
+      case Some(art) =>
+        val groupId = art("groupId").str
+        val artifactId = art("artifactId").str
+        val tryVersions =
+          List(project.v, art.obj.get("version").map(_.str).getOrElse(project.v)).distinct
+        tryVersions.view
+          .flatMap: version =>
+            try Some(loadPomDevZioDeps(groupId, artifactId, version))
+            catch case _: Exception => None
+          .headOption
+          .getOrElse(Nil)
+
+  private def loadPublishedDevZioDeps(artifactId: String, version: String): List[ZioDep] =
+    try loadPomDevZioDeps("dev.zio", artifactId, version)
+    catch
+      case ex: Exception =>
+        Console.err.println(
+          s"Failed to inspect transitive dev.zio deps for $artifactId:$version: $ex"
+        )
+        Nil
+
+  private def loadPomDevZioDeps(groupId: String, artifactId: String, version: String): List[ZioDep] =
+    DevZioPomDepsCache.getOrElseUpdate(
+      (groupId, artifactId, version),
+      readDevZioDepsFromPom(
+        httpGet(
+          s"https://repo1.maven.org/maven2/${groupId.replace('.', '/')}/$artifactId/$version/$artifactId-$version.pom"
+        ),
+        ownerVersion = version
+      )
+    )
+
+  private def readDevZioDepsFromPom(pom: String, ownerVersion: String): List[ZioDep] =
+    val doc = Jsoup.parse(pom, "", org.jsoup.parser.Parser.xmlParser())
+    val properties = pomProperties(doc, ownerVersion)
+    val managedVersions = pomManagedVersions(doc, properties, ownerVersion)
+    doc
+      .select("project > dependencies > dependency")
+      .asScala
+      .toList
+      .flatMap: dep =>
+        val group = Option(dep.selectFirst("groupId")).map(_.text.trim).getOrElse("")
+        val artifactId = Option(dep.selectFirst("artifactId")).map(_.text.trim).getOrElse("")
+        val rawVersion = Option(dep.selectFirst("version")).map(_.text.trim).getOrElse("")
+        val version =
+          resolvePomValue(rawVersion, properties)
+            .orElse(managedVersions.get(group -> artifactId))
+            .orElse(Option.when(group == "dev.zio" && rawVersion.isEmpty)(ownerVersion))
+            .getOrElse("")
+        if group == "dev.zio" && artifactId.nonEmpty && version.nonEmpty then
+          Some(ZioDep(DependencyOverride.stripScalaBinarySuffix(artifactId), artifactId, version))
+        else None
+      .distinctBy(dep => dep.artifactId -> dep.version)
+
+  private def pomProperties(
+      doc: org.jsoup.nodes.Document,
+      ownerVersion: String
+  ): Map[String, String] =
+    val fromPom =
+      Option(doc.selectFirst("project > properties"))
+        .toList
+        .flatMap(_.children().asScala)
+        .map(el => el.tagName() -> el.text.trim)
+        .toMap
+    fromPom ++ Map(
+      "project.version" -> ownerVersion,
+      "pom.version" -> ownerVersion,
+    )
+
+  private def pomManagedVersions(
+      doc: org.jsoup.nodes.Document,
+      properties: Map[String, String],
+      ownerVersion: String
+  ): Map[(String, String), String] =
+    doc
+      .select("project > dependencyManagement > dependencies > dependency")
+      .asScala
+      .toList
+      .flatMap: dep =>
+        val group = Option(dep.selectFirst("groupId")).map(_.text.trim).getOrElse("")
+        val artifactId = Option(dep.selectFirst("artifactId")).map(_.text.trim).getOrElse("")
+        val rawVersion = Option(dep.selectFirst("version")).map(_.text.trim).getOrElse("")
+        resolvePomValue(rawVersion, properties)
+          .orElse(Option.when(group == "dev.zio" && rawVersion.isEmpty)(ownerVersion))
+          .map(version => (group -> artifactId) -> version)
+      .toMap
+
+  private def resolvePomValue(
+      rawValue: String,
+      properties: Map[String, String]
+  ): Option[String] =
+    val trimmed = rawValue.trim
+    if trimmed.isEmpty then None
+    else
+      @annotation.tailrec
+      def loop(current: String, remaining: Int): String =
+        if remaining <= 0 then current
+        else
+          val replaced =
+            Placeholder.replaceAllIn(current, m => properties.getOrElse(m.group(1), m.matched))
+          if replaced == current then current else loop(replaced, remaining - 1)
+
+      val resolved = loop(trimmed, remaining = 6)
+      Option.when(resolved.nonEmpty && Placeholder.findFirstIn(resolved).isEmpty)(resolved)
+
+  private def httpGet(url: String): String =
+    import java.net.URI
+    import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+    import java.time.Duration
+    val client = HttpClient
+      .newBuilder()
+      .connectTimeout(Duration.ofSeconds(30))
+      .build()
+    val request = HttpRequest
+      .newBuilder(URI.create(url))
+      .timeout(Duration.ofSeconds(60))
+      .header("User-Agent", "scala3-community-build")
+      .GET()
+      .build()
+    val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+    if response.statusCode() != 200 then
+      throw RuntimeException(s"HTTP ${response.statusCode()} for $url")
+    response.body()

--- a/coordinator/src/main/scala/core.scala
+++ b/coordinator/src/main/scala/core.scala
@@ -102,6 +102,88 @@ case class ProjectsConfig(
 // Describes a simple textual replecement performed on path (relative Unix-style path to the file
 case class SourcePatch(path: String, pattern: String, replaceWith: String, selectVersion: Option[ScalaVersionRange] = None) derives ConfigReader
 case class ScalaVersionRange(min: Option[String] = None, max: Option[String] = None) derives ConfigReader
+
+/** scala-cli / Mill style coordinate, e.g. `dev.zio::zio:2.1.26`, `dev.zio:zio-test_2.13:2.1.26`.
+  *
+  * Format (same as Mill / scala-cli):
+  * {{{
+  *   org + scalaSuffix + name + platformSuffix + version
+  *   scalaSuffix:    ":" | "::" | ":::"   (none | binary | full)
+  *   platformSuffix: ":" | "::"           (none | platform)
+  * }}}
+  */
+case class DependencyOverride(coord: String) extends AnyVal:
+  private def parts: DependencyOverride.Parts =
+    DependencyOverride.parse(coord).getOrElse(DependencyOverride.Parts("", "", "", scalaColons = 1))
+
+  def organization: String = parts.organization
+  def artifact: String = parts.artifact
+  def version: String = parts.version
+
+  /** `true` for `::` (binary) or `:::` (full) scala version suffixes. */
+  def crossScalaVersion: Boolean = parts.scalaColons >= 2
+
+  /** `true` only for `:::` (full Scala version suffix). */
+  def crossFullScalaVersion: Boolean = parts.scalaColons == 3
+
+  /** Stable key for merge: org + logical artifact (binary suffix stripped). */
+  def moduleKey: String =
+    val logicalArtifact =
+      DependencyOverride.stripScalaBinarySuffix(parts.artifact)
+    s"${parts.organization}::$logicalArtifact"
+
+object DependencyOverride:
+  private val ScalaBinarySuffix = raw"_(?:3|(?:2\.\d+))$$".r
+
+  final case class Parts(
+      organization: String,
+      artifact: String,
+      version: String,
+      scalaColons: Int // 1 = none, 2 = binary, 3 = full
+  )
+
+  given ConfigReader[DependencyOverride] =
+    ConfigReader[String].map(DependencyOverride(_))
+
+  def scala(organization: String, artifact: String, version: String): DependencyOverride =
+    DependencyOverride(s"$organization::$artifact:$version")
+
+  def java(organization: String, artifact: String, version: String): DependencyOverride =
+    DependencyOverride(s"$organization:$artifact:$version")
+
+  def stripScalaBinarySuffix(artifact: String): String =
+    ScalaBinarySuffix.replaceFirstIn(artifact, "")
+
+  /** Parse a scala-cli / Mill dependency coordinate. */
+  def parse(coord: String): Option[Parts] =
+    val s = coord.trim
+    if s.isEmpty then None
+    else
+      val orgEnd = s.indexOf(':')
+      if orgEnd <= 0 then None
+      else
+        val organization = s.substring(0, orgEnd)
+        var i = orgEnd
+        var scalaColons = 0
+        while i < s.length && s.charAt(i) == ':' do
+          scalaColons += 1
+          i += 1
+        if scalaColons < 1 || scalaColons > 3 || i >= s.length then None
+        else
+          val nameStart = i
+          val platformStart = s.indexOf(':', nameStart)
+          if platformStart < 0 then None
+          else
+            val artifact = s.substring(nameStart, platformStart)
+            i = platformStart
+            var platformColons = 0
+            while i < s.length && s.charAt(i) == ':' do
+              platformColons += 1
+              i += 1
+            val version = s.substring(i)
+            if artifact.isEmpty || version.isEmpty || platformColons < 1 || platformColons > 2 then None
+            else Some(Parts(organization, artifact, version, scalaColons))
+
 case class ProjectBuildConfig(
     projects: ProjectsConfig = ProjectsConfig(),
     java: JavaConfig = JavaConfig(),
@@ -110,8 +192,9 @@ case class ProjectBuildConfig(
     git: GitConfig = GitConfig(),
     tests: TestingMode = TestingMode.default,
     sourceVersion: Option[String] = None,
-    migrationVersions: List[String] = Nil,   
-    sourcePatches: List[SourcePatch] = Nil
+    migrationVersions: List[String] = Nil,
+    sourcePatches: List[SourcePatch] = Nil,
+    dependencyOverrides: List[DependencyOverride] = Nil
 ) derives ConfigReader
 
 object ProjectBuildConfig {

--- a/coordinator/src/main/scala/encoding.scala
+++ b/coordinator/src/main/scala/encoding.scala
@@ -7,7 +7,8 @@ given Serialization = org.json4s.native.Serialization
 given Formats =
   Serialization.formats(NoTypeHints) +
     TestingModeEnumSerializer() + ProjectBuildDefSerializer +
-    UTCOffsetDateTimeSerializer() + ProjectSerializer()
+    UTCOffsetDateTimeSerializer() + ProjectSerializer() +
+    DependencyOverrideSerializer()
 
 object ProjectBuildDefSerializer
     extends FieldSerializer[ProjectBuildDef]({
@@ -41,6 +42,18 @@ class TestingModeEnumSerializer
         case TestingMode.Disabled    => JString(DisabledName)
         case TestingMode.CompileOnly => JString(CompileOnlyName)
         case TestingMode.Full        => JString(FullName)
+      }
+      (deserialize, serialize)
+    })
+
+/** Wire format is a plain scala-cli coordinate string. */
+class DependencyOverrideSerializer
+    extends CustomSerializer[DependencyOverride](_ => {
+      def deserialize: PartialFunction[JValue, DependencyOverride] = {
+        case JString(coord) => DependencyOverride(coord)
+      }
+      def serialize: PartialFunction[Any, JValue] = {
+        case DependencyOverride(coord) => JString(coord)
       }
       (deserialize, serialize)
     })

--- a/project-builder/mill/MillCommunityBuild.sc
+++ b/project-builder/mill/MillCommunityBuild.sc
@@ -522,6 +522,8 @@ object serialization {
     readwriter[String].bimap[TestingMode](toJson, fromJson)
   }
 
+  implicit lazy val DependencyOverrideR: Reader[DependencyOverride] =
+    implicitly[Reader[String]].map(DependencyOverride(_))
   implicit lazy val ProjectOverridesR: Reader[ProjectOverrides] = macroR
   implicit lazy val ProjectsConfigR: Reader[ProjectsConfig] = macroR
   implicit lazy val ProjectBuildConfigR: Reader[ProjectBuildConfig] = macroR

--- a/project-builder/mill/MillCommunityBuild.scala
+++ b/project-builder/mill/MillCommunityBuild.scala
@@ -482,6 +482,8 @@ object MillCommunityBuild {
       }
       readwriter[String].bimap[TestingMode](toJson, fromJson)
     }
+    given Reader[DependencyOverride] =
+      implicitly[Reader[String]].map(DependencyOverride(_))
     given Reader[ProjectOverrides] = macroR
     given Reader[ProjectsConfig] = macroR
     given Reader[ProjectBuildConfig] = macroR

--- a/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalacOptionsVersionPin.scala
+++ b/project-builder/mill/scalafix/output/src/main/scala/fix/MillScalacOptionsVersionPin.scala
@@ -32,6 +32,6 @@ object MillScalacOptionsVersionPin {
   }
   trait Shared extends ScalaModule with MillCommunityBuild.CommunityBuildCoursierModule with MillCommunityBuild.CommunityBuildScalaWorkerPathRefFix {
     override def scalaVersion = mill.Task("3.8.4")
-    override def scalacOptions = Task(Seq("-Werror")).mapScalacOptions(this.scalaVersion())
+    override def scalacOptions = Task(Seq("-Werror").mapScalacOptions(this.scalaVersion()))
   }
 }

--- a/project-builder/mill/scalafix/rules/src/main/scala/fix/Scala3CommunityBuildMillAdapter.scala
+++ b/project-builder/mill/scalafix/rules/src/main/scala/fix/Scala3CommunityBuildMillAdapter.scala
@@ -381,22 +381,30 @@ class Scala3CommunityBuildMillAdapter(
             )
 
           val updatedBody = body match {
-            case taskApply @ Term.Apply(receiver, Seq(block: Term.Block)) if receiver.syntax.contains("Task") =>
-              if (isMill1x) {
-                def mapLastExpr(stats: List[Stat]): List[Stat] = stats match {
-                  case init :+ (expr: Term) =>
-                    init :+ Term.Apply(
-                      Term.Select(expr, Term.Name("mapScalacOptions")),
-                      List(scalaVersionRef)
-                    )
-                  case other => other
-                }
-                Term.Apply(receiver, List(block.copy(stats = mapLastExpr(block.stats))))
-              } else
-                Term.Apply(
-                  Term.Select(taskApply, Term.Name("mapScalacOptions")),
-                  List(scalaVersionTaskRef)
-                )
+            case Term.Apply(receiver, Seq(taskBody)) if receiver.syntax.contains("Task") && isMill1x =>
+              def mapLastExpr(stats: List[Stat]): List[Stat] = stats match {
+                case init :+ (expr: Term) =>
+                  init :+ Term.Apply(
+                    Term.Select(expr, Term.Name("mapScalacOptions")),
+                    List(scalaVersionRef)
+                  )
+                case other => other
+              }
+              val mappedTaskBody = taskBody match {
+                case block: Term.Block =>
+                  block.copy(stats = mapLastExpr(block.stats))
+                case body if isBareScalacOptionsReference(body) =>
+                  body
+                case body =>
+                  mapScalacOptions(body)
+              }
+              Term.Apply(receiver, List(mappedTaskBody))
+
+            case taskApply @ Term.Apply(receiver, Seq(_: Term.Block)) if receiver.syntax.contains("Task") =>
+              Term.Apply(
+                Term.Select(taskApply, Term.Name("mapScalacOptions")),
+                List(scalaVersionTaskRef)
+              )
 
             // Task(foo) => foo.mapScalacOptions(scalaVersion)
             case Term.Apply(receiver, Seq(body: Term.Select)) if receiver.syntax.contains("Task") =>

--- a/project-builder/sbt/shared/CommunityBuildConfigFormats.scala
+++ b/project-builder/sbt/shared/CommunityBuildConfigFormats.scala
@@ -52,8 +52,15 @@ object CommunityBuildConfigFormats {
         unbuilder.beginObject(v)
         val projects = readOrDefault("projects", ProjectsConfig())
         val testsMode = readOrDefault[TestingMode, J]("tests", TestingMode.Full)
+        val dependencyOverrides = readOrDefault("dependencyOverrides", Array.empty[String])
+          .toSeq
+          .map(DependencyOverride(_))
         unbuilder.endObject()
-        ProjectBuildConfig(projects, testsMode)
+        ProjectBuildConfig(
+          projects = projects,
+          tests = testsMode,
+          dependencyOverrides = dependencyOverrides
+        )
       }
   }
 

--- a/project-builder/sbt/shared/CommunityBuildPluginShared.scala
+++ b/project-builder/sbt/shared/CommunityBuildPluginShared.scala
@@ -69,10 +69,13 @@ trait CommunityBuildPluginShared extends AutoPlugin {
                 org,
                 artifact,
                 version,
-                scalaCrossVersion
+                scalaColons
               ) =>
-            if (scalaCrossVersion) org %% artifact % version
-            else org % artifact % version
+            scalaColons match {
+              case 3 => org % artifact % version cross CrossVersion.full
+              case 2 => org %% artifact % version
+              case _ => org % artifact % version
+            }
         }
 
   private def stripScala3Suffix(s: String) = s match {
@@ -362,7 +365,33 @@ trait CommunityBuildPluginShared extends AutoPlugin {
         parsed.getOrElse(ProjectBuildConfig())
       }
 
-      val cState = state.value
+      var cState = state.value
+      val forcedDependencyOverrides =
+        Scala3CommunityBuild.Utils
+          .parseLibraryDependencies(
+            config.dependencyOverrides.map(_.coord),
+            scalaVersionArg
+          )
+          .map {
+            case LibraryDependency(org, artifact, version, scalaColons) =>
+              scalaColons match {
+                case 3 => org % artifact % version cross CrossVersion.full
+                case 2 => org %% artifact % version
+                case _ => org % artifact % version
+              }
+          }
+      if (forcedDependencyOverrides.nonEmpty) {
+        println(
+          s"Applying dependencyOverrides: ${forcedDependencyOverrides.mkString(", ")}"
+        )
+        val extracted0 = sbt.Project.extract(cState)
+        val refs = extracted0.structure.allProjectRefs
+        cState = cState.appendWithSession(
+          ((ThisBuild / dependencyOverrides) ++= forcedDependencyOverrides) +:
+            refs.map(ref => (ref / dependencyOverrides) ++= forcedDependencyOverrides)
+        )
+      }
+
       val extracted = sbt.Project.extract(cState)
       val s = extracted.structure
       val refsByName = s.allProjectRefs.map(r => r.project -> r).toMap

--- a/project-builder/scala-cli/build.scala
+++ b/project-builder/scala-cli/build.scala
@@ -38,6 +38,7 @@ import os.CommandResult
     scalaVersion = scalaVersion,
     repositoryDir = repositoryDir,
     mavenRepoURL = Option(mavenRepoURL).filterNot(_.isEmpty),
+    dependencyOverrides = config.dependencyOverrides,
     extraScalacOptions = Scala3CommunityBuild.Utils.splitScalacOptionArgs(extraScalacOptions).map {
       case s"REQUIRE:$opt" => opt
       case opt             => opt
@@ -138,6 +139,7 @@ class CliTaskEvaluator(
     scalaVersion: String,
     repositoryDir: os.Path,
     mavenRepoURL: Option[String],
+    dependencyOverrides: Seq[DependencyOverride],
     extraScalacOptions: List[String]
 ) extends TaskEvaluator[CliCommand] {
   import TaskEvaluator.*
@@ -156,9 +158,16 @@ class CliTaskEvaluator(
   def eval[T](task: CliCommand[T]): EvalResult[T] = {
     println(s"Evaluating: ${task}")
     val extraLibraryDependencies = Utils.extraLibraryDependencies(scalaVersion).map {
-      case Utils.LibraryDependency(org, artifact, version, scalaCrossVersion) =>
-        if (scalaCrossVersion) s"--dependency=$org::$artifact:$version"
-        else s"--dependency=$org:$artifact:$version"
+      case Utils.LibraryDependency(org, artifact, version, scalaColons) =>
+        val cross =
+          if (scalaColons == 3) ":::"
+          else if (scalaColons == 2) "::"
+          else ":"
+        s"--dependency=$org$cross$artifact:$version"
+    }
+    val dependencyOverrideArgs = dependencyOverrides.distinct.flatMap { dep =>
+      Utils.logOnce(s"Would apply dependencyOverride via scala-cli --dep: ${dep.coord}")
+      Seq("--dep", dep.coord)
     }
     val evalStart = System.currentTimeMillis()
     val stderrLines = collection.mutable.ArrayBuffer.empty[String]
@@ -176,6 +185,7 @@ class CliTaskEvaluator(
         "--scalac-option=-J-Xms4G",
         mavenRepoURL.map(s"--repository=" + _).toList,
         extraLibraryDependencies,
+        dependencyOverrideArgs,
         extraScalacOptions.map("--scala-option=" + _),
         "--platform=jvm"
       )
@@ -242,6 +252,8 @@ object uPickleSerializers {
 
   given Reader[ProjectOverrides] = macroR
   given Reader[ProjectsConfig] = macroR
+  given Reader[DependencyOverride] =
+    implicitly[Reader[String]].map(DependencyOverride(_))
   given Reader[ProjectBuildConfig] = macroR
   given Reader[ScalaVersionRange] = macroR
   given Reader[SourcePatch] = macroR

--- a/project-builder/shared/CommunityBuildCore.scala
+++ b/project-builder/shared/CommunityBuildCore.scala
@@ -14,7 +14,8 @@ object Scala3CommunityBuild {
   case class ProjectBuildConfig(
       projects: ProjectsConfig = ProjectsConfig(),
       tests: TestingMode = TestingMode.Full,
-      sourcePatches: Seq[SourcePatch] = Nil
+      sourcePatches: Seq[SourcePatch] = Nil,
+      dependencyOverrides: Seq[DependencyOverride] = Nil
   )
 
   case class ProjectOverrides(tests: Option[TestingMode] = None)
@@ -28,6 +29,90 @@ object Scala3CommunityBuild {
     case object Disabled extends TestingMode
     case object CompileOnly extends TestingMode
     case object Full extends TestingMode
+  }
+
+  /** scala-cli / Mill style coordinate, e.g. `dev.zio::zio:2.1.26`, `dev.zio:zio-test_2.13:2.1.26`.
+    *
+    * Format (same as Mill / scala-cli):
+    *   org + scalaSuffix + name + platformSuffix + version
+    *   scalaSuffix:    ":" | "::" | ":::"   (none | binary | full)
+    *   platformSuffix: ":" | "::"           (none | platform)
+    */
+  // Mill wraps imported .sc sources in a generated class, and nested value classes are illegal.
+  case class DependencyOverride(coord: String) {
+    private def parts: DependencyOverride.Parts =
+      DependencyOverride
+        .parse(coord)
+        .getOrElse(DependencyOverride.Parts("", "", "", 1))
+
+    def organization: String = parts.organization
+    def artifact: String = parts.artifact
+    def version: String = parts.version
+
+    /** `true` for `::` (binary) or `:::` (full) scala version suffixes. */
+    def crossScalaVersion: Boolean = parts.scalaColons >= 2
+
+    /** `true` only for `:::` (full Scala version suffix). */
+    def crossFullScalaVersion: Boolean = parts.scalaColons == 3
+
+    /** Stable key for merge: org + logical artifact (binary suffix stripped). */
+    def moduleKey: String = {
+      val logicalArtifact =
+        DependencyOverride.stripScalaBinarySuffix(parts.artifact)
+      parts.organization + "::" + logicalArtifact
+    }
+  }
+
+  object DependencyOverride {
+    private val ScalaBinarySuffix = raw"_(?:3|(?:2\.\d+))$$".r
+
+    final case class Parts(
+        organization: String,
+        artifact: String,
+        version: String,
+        scalaColons: Int // 1 = none, 2 = binary, 3 = full
+    )
+
+    def stripScalaBinarySuffix(artifact: String): String =
+      ScalaBinarySuffix.replaceFirstIn(artifact, "")
+
+    def parse(coord: String): Option[Parts] = {
+      val s = coord.trim
+      if (s.isEmpty) None
+      else {
+        val orgEnd = s.indexOf(':')
+        if (orgEnd <= 0) None
+        else {
+          val organization = s.substring(0, orgEnd)
+          var i = orgEnd
+          var scalaColons = 0
+          while (i < s.length && s.charAt(i) == ':') {
+            scalaColons += 1
+            i += 1
+          }
+          if (scalaColons < 1 || scalaColons > 3 || i >= s.length) None
+          else {
+            val nameStart = i
+            val platformStart = s.indexOf(':', nameStart)
+            if (platformStart < 0) None
+            else {
+              val artifact = s.substring(nameStart, platformStart)
+              i = platformStart
+              var platformColons = 0
+              while (i < s.length && s.charAt(i) == ':') {
+                platformColons += 1
+                i += 1
+              }
+              val version = s.substring(i)
+              if (
+                artifact.isEmpty || version.isEmpty || platformColons < 1 || platformColons > 2
+              ) None
+              else Some(Parts(organization, artifact, version, scalaColons))
+            }
+          }
+        }
+      }
+    }
   }
 
   case class SourcePatch(
@@ -681,37 +766,52 @@ object Scala3CommunityBuild {
         organization: String,
         artifact: String,
         version: String,
-        crossScalaVersion: Boolean
+        scalaColons: Int // 1 = none, 2 = binary, 3 = full
     ) {
+      def crossScalaVersion: Boolean = scalaColons >= 2
+      def crossFullScalaVersion: Boolean = scalaColons == 3
+
       override def toString(): String = {
-        val crossVersion = if (crossScalaVersion) "%%" else "%"
+        val crossVersion =
+          if (crossFullScalaVersion) "%%%"
+          else if (crossScalaVersion) "%%"
+          else "%"
         s"$organization $crossVersion $artifact % $version"
       }
     }
 
     private def escapeScalaVersion(scalaVersion: String)(str: String): String =
       str.replace("<SCALA_VERSION>", scalaVersion)
-    final val ExtraLibraryDependenciesProp = "communitybuild.project.dependencies.add"
-    def extraLibraryDependencies(scalaVersion: String): Seq[LibraryDependency] = sys.props
-      .getOrElse(ExtraLibraryDependenciesProp, "")
-      .split(';')
-      .map(escapeScalaVersion(scalaVersion)(_))
-      .filter(_.nonEmpty)
-      .map(dep => dep.trim().split(':'))
-      .flatMap {
-        // org::artifact:version
-        case Array(org, "", artifact, version) =>
-          Some(LibraryDependency(org, artifact, version, crossScalaVersion = true))
-        // org:artifact:version
-        case Array(org, artifact, version) =>
-          Some(LibraryDependency(org, artifact, version, crossScalaVersion = false))
-        // other
-        case segments =>
-          logOnce(s"Invalid dependency format, segments=${segments.toList}")
-          None
+
+    def parseLibraryDependency(coord: String): Option[LibraryDependency] =
+      DependencyOverride.parse(coord).map { p =>
+        LibraryDependency(
+          p.organization,
+          p.artifact,
+          p.version,
+          scalaColons = p.scalaColons
+        )
       }
-      .toList
-      .map { dep =>
+
+    def parseLibraryDependencies(
+        coords: Seq[String],
+        scalaVersion: String
+    ): Seq[LibraryDependency] =
+      coords
+        .map(escapeScalaVersion(scalaVersion)(_))
+        .filter(_.nonEmpty)
+        .flatMap(parseLibraryDependency)
+
+    final val ExtraLibraryDependenciesProp = "communitybuild.project.dependencies.add"
+    def extraLibraryDependencies(scalaVersion: String): Seq[LibraryDependency] =
+      parseLibraryDependencies(
+        sys.props
+          .getOrElse(ExtraLibraryDependenciesProp, "")
+          .split(';')
+          .filter(_.nonEmpty)
+          .toSeq,
+        scalaVersion
+      ).map { dep =>
         logOnce(s"Would include extra dependency: $dep")
         dep
       }


### PR DESCRIPTION
Adds automatic config entries to force upgrade of ZIO-based projects to zio 2.1.26 containing fix for https://github.com/scala/scala3/issues/25690 regressions caused by broken macros and improvements to constant folding in the compiler 
Best effort approach, resolves issues in ~60 projects, works only when project uses only stable release of ZIO 2.x (no upgrade if using RC or M version due to incompatible API) 